### PR TITLE
feat(rubric): weighted multi-dimensional scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,46 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — weighted rubric scorecard
+
+Each advisory agent now represents a dimension of a multi-dimensional rubric
+with a default weight. The consolidator emits a pre-formatted ASCII scorecard
+alongside the legacy verdict.
+
+- New tool `score_rubric` (`src/tools/score-rubric.ts`): pure function over
+  per-agent scores (0-100) and optional weight overrides; returns
+  `weighted_score`, per-dimension breakdown with bars, `passes_threshold`,
+  `ignored_agents`, and a pre-formatted `scorecard_text`.
+- `AgentDef` extended with `weight: number` and `dimension: string`. Default
+  weights sum to 100 across the seven advisory agents (Architecture 18%,
+  Security 18%, Application Code 18%, Data Layer 14%, Testing & QA 14%, Code
+  Quality 10%, Business & UX 8%). Meta-agents (tech-lead-planner,
+  tech-lead-consolidator) carry weight 0 — they don't score a dimension.
+- `apply_consolidation_rules` accepts optional per-agent `score`/`score_rationale`,
+  optional `weights` override, optional `threshold` (default 75), and optional
+  `min_score`. Returns `rubric: RubricOutput | null` and `downgraded_by_score`.
+  When `min_score` is set, an APPROVED verdict with weighted score below the
+  floor is downgraded to CHANGES_REQUIRED. Backward compatible: callers that
+  omit scores get the legacy output shape and verdict logic.
+- Each advisory agent file (`agents/*.md`) now ships a `## Score` section with
+  a calibration table (90-100 / 70-89 / 50-69 / 30-49 / 0-29 bands) specific
+  to that dimension, plus the protocol for emitting `Score: NN/100`.
+- Skill `skills/squad/SKILL.md` updated to capture per-agent scores into the
+  reports array and surface `rubric.scorecard_text` verbatim in the final
+  output. Tech-lead-planner/consolidator excluded (weight 0).
+- Weight renormalisation: when only a subset of agents scores (partial pass),
+  the rubric renormalises across the agents that actually scored. A 4-of-9
+  advisory still produces a meaningful weighted score over those 4.
+- `tests/score-rubric.test.ts` and `tests/consolidate-rubric.test.ts` cover
+  the math (renormalisation, weight overrides, sum=100 validation, threshold
+  edge cases), backward compatibility, and the `min_score` downgrade rule.
+
 Planned for a future minor:
 
-- Streaming SHA-256 over `fs.createReadStream` for any large bundled asset reads
-  (avoids `readFileSync` doubling memory).
+- `.squad.yaml` reader so weight overrides live with the repo.
+- Per-PR memory of accept/reject decisions feeding back into agent prompts.
+- Streaming SHA-256 over `fs.createReadStream` for any large bundled asset
+  reads (avoids `readFileSync` doubling memory).
 - Property-based tests for severity/consolidation rules via `fast-check`.
 
 ## [0.6.0] - 2026-05-10

--- a/agents/product-owner.md
+++ b/agents/product-owner.md
@@ -88,3 +88,29 @@ Objective summary of the evaluation.
 - Be pragmatic: not every gap is a blocker, classify by severity
 - Frame impact in business terms, not technical ones
 - Without a user story, judge by observable behavior and product common sense
+
+## Score
+
+At the end of your advisory output, emit exactly:
+
+```
+Score: <NN>/100
+Score rationale: <one sentence on what drove the score>
+```
+
+The score is YOUR dimension's contribution to the squad rubric (`Business & UX`). The consolidator will weight it against other agents and compare against the threshold (default 75) to produce the final scorecard.
+
+### Calibration
+
+- 90-100: requirement matches the change; UX clear; business value evident.
+- 70-89: minor mismatch with stated requirement or UX awkwardness.
+- **50-69: one Major — business rule contradicted, UX broken on critical flow, requirement absent.**
+- 30-49: change does not deliver claimed value; conflicts with PO intent.
+- 0-29: should not be built; halt.
+
+### Notes
+
+- Score is per-agent. Do not score other dimensions.
+- Score reflects the slice of files you reviewed, not the whole change.
+- A score of 0 means halt — equivalent to a Blocker. Do not emit 0 unless you would also raise a Blocker.
+- An honest 65 is more useful than a generous 80; the rubric is auditable.

--- a/agents/senior-architect.md
+++ b/agents/senior-architect.md
@@ -125,3 +125,29 @@ Summary of the diagnosis and long-term view.
 - Distinguish "ideal" from "acceptable for now"
 - Avoid astronaut architecture — prefer pragmatic solutions
 - If the issue is implementation (not design), forward to the right agent
+
+## Score
+
+At the end of your advisory output, emit exactly:
+
+```
+Score: <NN>/100
+Score rationale: <one sentence on what drove the score>
+```
+
+The score is YOUR dimension's contribution to the squad rubric (`Architecture`). The consolidator will weight it against other agents and compare against the threshold (default 75) to produce the final scorecard.
+
+### Calibration
+
+- 90-100: clean module/domain boundaries, DI lifetimes correct, no coupling regression, extensibility clear.
+- 70-89: minor issues (over-eager abstraction, ambiguous responsibility split) but no actionable Major.
+- **50-69: at least one Major (cross-module coupling, wrong DI lifetime, hidden mutable state).**
+- 30-49: multiple Majors or one Blocker that endangers structural integrity.
+- 0-29: architecture-level break; halt.
+
+### Notes
+
+- Score is per-agent. Do not score other dimensions.
+- Score reflects the slice of files you reviewed, not the whole change.
+- A score of 0 means halt — equivalent to a Blocker. Do not emit 0 unless you would also raise a Blocker.
+- An honest 65 is more useful than a generous 80; the rubric is auditable.

--- a/agents/senior-dba.md
+++ b/agents/senior-dba.md
@@ -141,3 +141,29 @@ Summary and prioritized risks.
 - Be conservative with migrations — prefer additive operations
 - Challenge every query without WHERE or with SELECT *
 - Validate suggested indexes do not degrade write performance
+
+## Score
+
+At the end of your advisory output, emit exactly:
+
+```
+Score: <NN>/100
+Score rationale: <one sentence on what drove the score>
+```
+
+The score is YOUR dimension's contribution to the squad rubric (`Data Layer`). The consolidator will weight it against other agents and compare against the threshold (default 75) to produce the final scorecard.
+
+### Calibration
+
+- 90-100: queries efficient, migrations safe and reversible, EF mappings correct, no concurrency hazard.
+- 70-89: minor inefficiencies or missing indexes; no data-integrity risk.
+- **50-69: one Major — N+1 query, missing transaction, broken concurrency control, mismatched stack mix.**
+- 30-49: data integrity at risk (race, lost update, irreversible migration without backout).
+- 0-29: data corruption likely; halt.
+
+### Notes
+
+- Score is per-agent. Do not score other dimensions.
+- Score reflects the slice of files you reviewed, not the whole change.
+- A score of 0 means halt — equivalent to a Blocker. Do not emit 0 unless you would also raise a Blocker.
+- An honest 65 is more useful than a generous 80; the rubric is auditable.

--- a/agents/senior-dev-reviewer.md
+++ b/agents/senior-dev-reviewer.md
@@ -612,3 +612,29 @@ Summary and decision. Restate the overall score and the top 1–3 things the aut
 - Be specific: always reference file and line
 - When the language idiom and the existing codebase conflict, side with the existing codebase consistency and flag the inconsistency for separate discussion
 - Remember: the goal is that the author learns, not just that they fix
+
+## Score
+
+At the end of your advisory output, emit exactly:
+
+```
+Score: <NN>/100
+Score rationale: <one sentence on what drove the score>
+```
+
+The score is YOUR dimension's contribution to the squad rubric (`Code Quality`). The consolidator will weight it against other agents and compare against the threshold (default 75) to produce the final scorecard.
+
+### Calibration
+
+- 90-100: idiomatic, readable, well-named, async/error patterns clean.
+- 70-89: minor style or naming smells; no idiom violations of consequence.
+- 50-69: one Major — wrong async pattern, swallowed exception, name that misleads readers.
+- 30-49: multiple Majors; reviewer fatigue indicator.
+- 0-29: code unmaintainable as-is; halt.
+
+### Notes
+
+- Score is per-agent. Do not score other dimensions.
+- Score reflects the slice of files you reviewed, not the whole change.
+- A score of 0 means halt — equivalent to a Blocker. Do not emit 0 unless you would also raise a Blocker.
+- An honest 65 is more useful than a generous 80; the rubric is auditable.

--- a/agents/senior-dev-security.md
+++ b/agents/senior-dev-security.md
@@ -138,3 +138,29 @@ Summary of risks and prioritized recommendations.
 - Do not generate false positives — only report with real or highly likely evidence
 - Prioritize by real impact, not theoretical checklist
 - Explicitly record what could not be validated
+
+## Score
+
+At the end of your advisory output, emit exactly:
+
+```
+Score: <NN>/100
+Score rationale: <one sentence on what drove the score>
+```
+
+The score is YOUR dimension's contribution to the squad rubric (`Security`). The consolidator will weight it against other agents and compare against the threshold (default 75) to produce the final scorecard.
+
+### Calibration
+
+- 90-100: no OWASP issue; authn/authz tight; secrets handled; no new dependency risk.
+- 70-89: minor concerns (missing input length cap, weak rate limit) — not exploitable.
+- **50-69: one Major — IDOR, missing authz check, secret in log, unsafe dependency.**
+- 30-49: exploitable today (auth bypass, SQLi, RCE); Blocker territory.
+- 0-29: critical security break; halt.
+
+### Notes
+
+- Score is per-agent. Do not score other dimensions.
+- Score reflects the slice of files you reviewed, not the whole change.
+- A score of 0 means halt — equivalent to a Blocker. Do not emit 0 unless you would also raise a Blocker.
+- An honest 65 is more useful than a generous 80; the rubric is auditable.

--- a/agents/senior-developer.md
+++ b/agents/senior-developer.md
@@ -184,3 +184,29 @@ Summary of the analysis and confidence in the solution for production.
 - Focus on real, probable bugs — not unlikely theoretical scenarios
 - Production is hostile: anything that can go wrong, will
 - Moderate duplication is acceptable when the alternative is a premature abstraction
+
+## Score
+
+At the end of your advisory output, emit exactly:
+
+```
+Score: <NN>/100
+Score rationale: <one sentence on what drove the score>
+```
+
+The score is YOUR dimension's contribution to the squad rubric (`Application Code`). The consolidator will weight it against other agents and compare against the threshold (default 75) to produce the final scorecard.
+
+### Calibration
+
+- 90-100: correctness solid, robustness considered, API contract honoured, observability in place.
+- 70-89: minor robustness gaps (one ambiguous error path, missing log) but no behavioural break.
+- **50-69: one Major — broken contract, missing error handling, observability hole on critical path.**
+- 30-49: multiple Majors or behaviour change with no test/log support.
+- 0-29: ships broken; halt.
+
+### Notes
+
+- Score is per-agent. Do not score other dimensions.
+- Score reflects the slice of files you reviewed, not the whole change.
+- A score of 0 means halt — equivalent to a Blocker. Do not emit 0 unless you would also raise a Blocker.
+- An honest 65 is more useful than a generous 80; the rubric is auditable.

--- a/agents/senior-qa.md
+++ b/agents/senior-qa.md
@@ -150,3 +150,29 @@ Confidence summary and prioritized recommendations.
 - Focus on critical paths: what causes the most damage if it fails in production?
 - Tests should serve as living documentation of expected behavior
 - Do not require tests for trivial code (getters, setters, simple DTOs)
+
+## Score
+
+At the end of your advisory output, emit exactly:
+
+```
+Score: <NN>/100
+Score rationale: <one sentence on what drove the score>
+```
+
+The score is YOUR dimension's contribution to the squad rubric (`Testing & QA`). The consolidator will weight it against other agents and compare against the threshold (default 75) to produce the final scorecard.
+
+### Calibration
+
+- 90-100: tests cover golden + edge paths; mocks honest; no flake risk; strategy fits the change.
+- 70-89: minor coverage gaps; mocks slightly liberal but not wrong.
+- **50-69: one Major — critical path untested, mock hides real behaviour, missing failure-mode test.**
+- 30-49: behaviour change without tests; flaky tests added; coverage regression.
+- 0-29: tests prove nothing; halt.
+
+### Notes
+
+- Score is per-agent. Do not score other dimensions.
+- Score reflects the slice of files you reviewed, not the whole change.
+- A score of 0 means halt — equivalent to a Blocker. Do not emit 0 unless you would also raise a Blocker.
+- An honest 65 is more useful than a generous 80; the rubric is auditable.

--- a/skills/squad/SKILL.md
+++ b/skills/squad/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: squad
-description: Multi-agent advisory squad workflow. Two modes — implement (default) and review. Implement runs the full squad-dev orchestration (classification, risk scoring, agent selection, planner, advisory parallel review, gates, implementation, consolidation). Review runs only the advisory portion against an existing diff/branch/PR with no implementation. Both modes use the same MCP tools and dispatch named subagents (senior-architect, senior-dba, senior-developer, senior-dev-reviewer, senior-dev-security, senior-qa, tech-lead-planner, tech-lead-consolidator, product-owner). Trigger when the user types /squad, /squad-review, or asks to "run the squad", "advisory review", "implement with squad-dev", "code review by specialists", or invokes any squad-dev workflow.
+description: Multi-agent advisory squad workflow. Two modes — implement (default) and review. Implement runs the full squad-dev orchestration (classification, risk scoring, agent selection, planner, advisory parallel review, gates, implementation, consolidation). Review runs only the advisory portion against an existing diff/branch/PR with no implementation. Both modes use the same MCP tools and dispatch named subagents (senior-architect, senior-dba, senior-developer, senior-dev-reviewer, senior-dev-security, senior-qa, tech-lead-planner, tech-lead-consolidator, product-owner). Each agent emits a Score 0-100 for its dimension; the consolidator weights them into a rubric scorecard. Trigger when the user types /squad, /squad-review, or asks to "run the squad", "advisory review", "implement with squad-dev", "code review by specialists", or invokes any squad-dev workflow.
 ---
 
 # Skill: Squad
@@ -12,7 +12,7 @@ Single skill that hosts both the **implement** workflow (full squad-dev orchestr
 | Mode                  | Triggered by             | What it does                                                                                                                                                                                  |
 | --------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `implement` (default) | `/squad <task>`          | Full squad-dev: classify → score risk → select advisory agents → planner → Gate 1 (plan approval) → parallel advisory → Gate 2 (Blocker halt) → implementation → consolidator → final verdict |
-| `review`              | `/squad-review [target]` | Review only: same agents on an existing diff/branch/PR, never implements. Output is consolidated advisory verdict.                                                                            |
+| `review`              | `/squad-review [target]` | Review only: same agents on an existing diff/branch/PR, never implements. Output is consolidated advisory verdict + scorecard.                                                                |
 
 The user-invoked entry command determines the mode. If the prompt contains `--review`, treat as review mode regardless of entry.
 
@@ -40,8 +40,9 @@ Use the `squad` MCP server for orchestration. Available tools:
 - `compose_advisory_bundle` — full bundle: workflow + slices_by_agent + plan_validation
 - `validate_plan_text` — advisory check for inviolable-rule violations in a plan
 - `get_agent_definition` — read an agent's full markdown (used when sub-agent context needs the role)
-- `apply_consolidation_rules` — final verdict (APPROVED / CHANGES_REQUIRED / REJECTED)
-- `list_agents` — list configured agents with role and ownership
+- `apply_consolidation_rules` — final verdict + rubric scorecard (when reports carry scores)
+- `score_rubric` — standalone rubric calculator (also invoked internally by `apply_consolidation_rules` when reports carry scores)
+- `list_agents` — list configured agents with role, ownership, and dimension weight
 
 Available named subagents (Claude Code `Task(subagent_type=…)`): `product-owner`, `senior-architect`, `senior-dba`, `senior-developer`, `senior-dev-reviewer`, `senior-dev-security`, `senior-qa`, `tech-lead-planner`, `tech-lead-consolidator`. The plugin registers these from `agents/`. In other MCP clients, the same role can be obtained via `get_agent_definition` and embedded in a generic dispatch prompt.
 
@@ -101,9 +102,30 @@ You are participating in an advisory review.
 As {agent role}, produce findings tagged Blocker / Major / Minor / Suggestion per _shared/_Severity-and-Ownership.md.
 For each finding: severity, file:line, observation, recommendation.
 You do NOT implement. Output is text only.
+
+## Score
+At the end, emit on its own line:
+  Score: NN/100
+  Score rationale: <one sentence>
+
+Use the calibration table in your role file (see ## Score section). Honest 65
+is more useful than generous 80 — the rubric is auditable.
 ```
 
-Each agent emits findings tagged Blocker / Major / Minor / Suggestion per `_shared/_Severity-and-Ownership.md`.
+Each agent emits findings tagged Blocker / Major / Minor / Suggestion per `_shared/_Severity-and-Ownership.md` AND a single `Score: NN/100` line. Capture both into the per-agent report.
+
+When you build the `reports[]` array for `apply_consolidation_rules`, include the score:
+
+```json
+{
+  "agent": "senior-architect",
+  "findings": [...],
+  "score": 82,
+  "score_rationale": "clean DI, one Major on cross-module coupling"
+}
+```
+
+Tech-lead-planner and tech-lead-consolidator do NOT emit scores (weight 0).
 
 ## Phase 6 — Gate 2: Blocker halt
 
@@ -131,7 +153,15 @@ Delta only. Same consent rules as Phase 3.
 
 ## Phase 10 — TechLead-Consolidator (both modes)
 
-Dispatch `tech-lead-consolidator` subagent via `Task(subagent_type="tech-lead-consolidator", description="Consolidate verdict", prompt=<all reports + apply_consolidation_rules output>)`. It emits the final verdict (`APPROVED` / `CHANGES_REQUIRED` / `REJECTED`) plus rollback plan / mitigation guidance.
+Call `apply_consolidation_rules` with the reports array (each with `score` populated). The tool emits:
+
+- Verdict (APPROVED / CHANGES_REQUIRED / REJECTED) per severity rules
+- `rubric` with `weighted_score`, per-dimension breakdown, and `scorecard_text` (pre-formatted ASCII)
+- `downgraded_by_score: true` if you supplied `min_score` and the weighted score fell below it (only downgrades APPROVED → CHANGES_REQUIRED, never further)
+
+Then dispatch `tech-lead-consolidator` subagent via `Task(subagent_type="tech-lead-consolidator", description="Consolidate verdict", prompt=<all reports + apply_consolidation_rules output INCLUDING the rubric.scorecard_text>)`. The consolidator surfaces the verdict + scorecard + rollback plan / mitigation guidance.
+
+The final user-facing output MUST include the `rubric.scorecard_text` block verbatim — that's the visible artifact that distinguishes squad from generic reviewers.
 
 ## Phase 11 — Gate 3: reject loop (implement mode only, max 2 iterations)
 
@@ -151,6 +181,7 @@ Single consolidated report:
 
 - Diff summary: files, work_type, risk
 - Per-agent findings (severity tagged)
+- `rubric.scorecard_text` block
 - Cross-cutting concerns
 - Final verdict: `APPROVED` / `CHANGES_REQUIRED` / `REJECTED`
 - Rollback / mitigation guidance
@@ -184,6 +215,26 @@ The plugin manifest declares `agents/` so Claude Code registers `product-owner`,
 - **Suggestion**: improvement idea; does not block
 
 Risk score: 0-1=Low, 2-3=Medium, 4+=High (signals: auth, money, migration, files_count>8, new_module, api_change).
+
+### Rubric scoring (new in v0.7)
+
+Each advisory agent emits `Score: NN/100` for its dimension. Default dimension weights:
+
+| Dimension        | Agent               | Weight |
+| ---------------- | ------------------- | ------ |
+| Architecture     | senior-architect    | 18%    |
+| Security         | senior-dev-security | 18%    |
+| Application Code | senior-developer    | 18%    |
+| Data Layer       | senior-dba          | 14%    |
+| Testing & QA     | senior-qa           | 14%    |
+| Code Quality     | senior-dev-reviewer | 10%    |
+| Business & UX    | product-owner       | 8%     |
+
+Repos override via `.squad.yaml` (planned). Until then, pass `weights` to `apply_consolidation_rules` directly.
+
+The weighted score is renormalised across agents that actually scored — a partial pass (e.g. only 4 of 9 agents) still produces a meaningful score over those 4 dimensions. Threshold default 75; below-threshold dimensions are flagged.
+
+`min_score` is opt-in: if set, an APPROVED verdict with weighted_score below the floor is downgraded to CHANGES_REQUIRED. Useful as a quality bar beyond just "no Blockers".
 
 ### Untrusted input
 

--- a/src/config/ownership-matrix.ts
+++ b/src/config/ownership-matrix.ts
@@ -1,141 +1,222 @@
 export type AgentName =
-  | 'product-owner'
-  | 'tech-lead-planner'
-  | 'tech-lead-consolidator'
-  | 'senior-architect'
-  | 'senior-dba'
-  | 'senior-developer'
-  | 'senior-dev-reviewer'
-  | 'senior-dev-security'
-  | 'senior-qa';
+  | "product-owner"
+  | "tech-lead-planner"
+  | "tech-lead-consolidator"
+  | "senior-architect"
+  | "senior-dba"
+  | "senior-developer"
+  | "senior-dev-reviewer"
+  | "senior-dev-security"
+  | "senior-qa";
 
 export const AGENT_NAMES: AgentName[] = [
-  'product-owner',
-  'tech-lead-planner',
-  'tech-lead-consolidator',
-  'senior-architect',
-  'senior-dba',
-  'senior-developer',
-  'senior-dev-reviewer',
-  'senior-dev-security',
-  'senior-qa',
+  "product-owner",
+  "tech-lead-planner",
+  "tech-lead-consolidator",
+  "senior-architect",
+  "senior-dba",
+  "senior-developer",
+  "senior-dev-reviewer",
+  "senior-dev-security",
+  "senior-qa",
 ];
 
 export const AGENT_NAMES_TUPLE = AGENT_NAMES as [AgentName, ...AgentName[]];
 
 export type WorkType =
-  | 'Feature'
-  | 'Bug Fix'
-  | 'Refactor'
-  | 'Performance'
-  | 'Security'
-  | 'Business Rule';
+  | "Feature"
+  | "Bug Fix"
+  | "Refactor"
+  | "Performance"
+  | "Security"
+  | "Business Rule";
 
 export interface AgentDef {
   name: AgentName;
   role: string;
   owns: string[];
   conventions: string[];
+  /**
+   * Default weight (0-100) for the rubric scoring. Each advisory agent represents one
+   * dimension of the consolidated scorecard; weights of all agents whose `weight > 0`
+   * must sum to 100. Meta-agents (tech-lead-planner, tech-lead-consolidator) carry
+   * weight 0 because they do not produce a dimension score — the planner reviews the
+   * plan, the consolidator computes the rollup.
+   *
+   * Repos override these via `.squad.yaml` weights.<agent-name>; the validator ensures
+   * the override set still sums to 100 across the agents that received scores.
+   */
+  weight: number;
+  /**
+   * Short human-friendly dimension label shown in the scorecard. e.g. "Security",
+   * "Architecture". Empty string for meta-agents (weight 0).
+   */
+  dimension: string;
 }
 
 export const AGENTS: Record<AgentName, AgentDef> = {
-  'product-owner': {
-    name: 'product-owner',
-    role: 'Business value, UX, requirements fit',
-    owns: ['Business value and requirements', 'User experience'],
+  "product-owner": {
+    name: "product-owner",
+    role: "Business value, UX, requirements fit",
+    owns: ["Business value and requirements", "User experience"],
     conventions: [],
+    weight: 8,
+    dimension: "Business & UX",
   },
-  'tech-lead-planner': {
-    name: 'tech-lead-planner',
-    role: 'Pre-implementation trade-offs and viability',
-    owns: ['Plan viability and trade-off framing (pre-impl)'],
+  "tech-lead-planner": {
+    name: "tech-lead-planner",
+    role: "Pre-implementation trade-offs and viability",
+    owns: ["Plan viability and trade-off framing (pre-impl)"],
     conventions: [],
+    weight: 0,
+    dimension: "",
   },
-  'tech-lead-consolidator': {
-    name: 'tech-lead-consolidator',
-    role: 'Post-implementation final verdict',
-    owns: ['Final merge verdict', 'Design trade-offs', 'CI/CD and deploy', 'Technical debt'],
-    conventions: [],
-  },
-  'senior-architect': {
-    name: 'senior-architect',
-    role: 'Boundaries, DI, scalability',
-    owns: ['Module and domain boundaries', 'Coupling', 'DI registrations and lifetimes', 'Architectural scalability'],
-    conventions: [
-      '*ServiceCollectionExtensions.cs',
-      'Program.cs',
-      'Startup.cs',
-      '*.csproj',
-      'Directory.Packages.props',
+  "tech-lead-consolidator": {
+    name: "tech-lead-consolidator",
+    role: "Post-implementation final verdict",
+    owns: [
+      "Final merge verdict",
+      "Design trade-offs",
+      "CI/CD and deploy",
+      "Technical debt",
     ],
+    conventions: [],
+    weight: 0,
+    dimension: "",
   },
-  'senior-dba': {
-    name: 'senior-dba',
-    role: 'Queries, migrations, EF, cache',
-    owns: ['Queries and database performance', 'Migrations and schema', 'EF mappings', 'Data cache', 'Database concurrency'],
-    conventions: [
-      '*Repository.cs',
-      '*Configuration.cs (EF entity config)',
-      'Migrations/* (default `dotnet ef migrations` naming)',
+  "senior-architect": {
+    name: "senior-architect",
+    role: "Boundaries, DI, scalability",
+    owns: [
+      "Module and domain boundaries",
+      "Coupling",
+      "DI registrations and lifetimes",
+      "Architectural scalability",
     ],
+    conventions: [
+      "*ServiceCollectionExtensions.cs",
+      "Program.cs",
+      "Startup.cs",
+      "*.csproj",
+      "Directory.Packages.props",
+    ],
+    weight: 18,
+    dimension: "Architecture",
   },
-  'senior-developer': {
-    name: 'senior-developer',
-    role: 'Correctness, robustness, APIs, observability',
-    owns: ['Technical correctness', 'Robustness', 'API contracts', 'External integrations', 'Observability', 'App performance'],
+  "senior-dba": {
+    name: "senior-dba",
+    role: "Queries, migrations, EF, cache",
+    owns: [
+      "Queries and database performance",
+      "Migrations and schema",
+      "EF mappings",
+      "Data cache",
+      "Database concurrency",
+    ],
+    conventions: [
+      "*Repository.cs",
+      "*Configuration.cs (EF entity config)",
+      "Migrations/* (default `dotnet ef migrations` naming)",
+    ],
+    weight: 14,
+    dimension: "Data Layer",
+  },
+  "senior-developer": {
+    name: "senior-developer",
+    role: "Correctness, robustness, APIs, observability",
+    owns: [
+      "Technical correctness",
+      "Robustness",
+      "API contracts",
+      "External integrations",
+      "Observability",
+      "App performance",
+    ],
     conventions: [],
+    weight: 18,
+    dimension: "Application Code",
   },
-  'senior-dev-reviewer': {
-    name: 'senior-dev-reviewer',
-    role: 'Readability, idioms, naming',
-    owns: ['Readability and code smells', 'C#/.NET best practices', 'Naming conventions'],
+  "senior-dev-reviewer": {
+    name: "senior-dev-reviewer",
+    role: "Readability, idioms, naming",
+    owns: [
+      "Readability and code smells",
+      "C#/.NET best practices",
+      "Naming conventions",
+    ],
     conventions: [],
+    weight: 10,
+    dimension: "Code Quality",
   },
-  'senior-dev-security': {
-    name: 'senior-dev-security',
-    role: 'OWASP, authz, sensitive data',
-    owns: ['OWASP Top 10', 'Authentication and authorization', 'Sensitive data protection'],
-    conventions: ['*Controller.cs (with [ApiController])', 'Auth*.cs'],
+  "senior-dev-security": {
+    name: "senior-dev-security",
+    role: "OWASP, authz, sensitive data",
+    owns: [
+      "OWASP Top 10",
+      "Authentication and authorization",
+      "Sensitive data protection",
+    ],
+    conventions: ["*Controller.cs (with [ApiController])", "Auth*.cs"],
+    weight: 18,
+    dimension: "Security",
   },
-  'senior-qa': {
-    name: 'senior-qa',
-    role: 'Test coverage, strategy, reliability',
-    owns: ['Test quality and coverage', 'Test strategy'],
-    conventions: ['*Tests.cs', '*Test.cs', '*/Tests/*'],
+  "senior-qa": {
+    name: "senior-qa",
+    role: "Test coverage, strategy, reliability",
+    owns: ["Test quality and coverage", "Test strategy"],
+    conventions: ["*Tests.cs", "*Test.cs", "*/Tests/*"],
+    weight: 14,
+    dimension: "Testing & QA",
   },
 };
 
-export const SQUAD_BY_TYPE: Record<WorkType, { core: AgentName[]; conditional: { agent: AgentName; when: string }[] }> = {
+/**
+ * Default rubric weights derived from AGENTS. Sum of advisory dimensions = 100.
+ * Exposed as a separate constant so `.squad.yaml` overrides have a clean baseline
+ * to merge against without rebuilding from AGENTS.
+ */
+export const DEFAULT_RUBRIC_WEIGHTS: Record<AgentName, number> =
+  Object.fromEntries(
+    (Object.entries(AGENTS) as [AgentName, AgentDef][]).map(([name, def]) => [
+      name,
+      def.weight,
+    ]),
+  ) as Record<AgentName, number>;
+
+export const SQUAD_BY_TYPE: Record<
+  WorkType,
+  { core: AgentName[]; conditional: { agent: AgentName; when: string }[] }
+> = {
   Feature: {
-    core: ['product-owner', 'senior-developer', 'senior-qa'],
+    core: ["product-owner", "senior-developer", "senior-qa"],
     conditional: [
-      { agent: 'senior-dba', when: 'data touched' },
-      { agent: 'senior-architect', when: 'new module' },
-      { agent: 'senior-dev-security', when: 'endpoint touched' },
+      { agent: "senior-dba", when: "data touched" },
+      { agent: "senior-architect", when: "new module" },
+      { agent: "senior-dev-security", when: "endpoint touched" },
     ],
   },
-  'Bug Fix': {
-    core: ['senior-developer', 'senior-qa'],
+  "Bug Fix": {
+    core: ["senior-developer", "senior-qa"],
     conditional: [
-      { agent: 'senior-dba', when: 'query/cache' },
-      { agent: 'senior-dev-security', when: 'security bug' },
+      { agent: "senior-dba", when: "query/cache" },
+      { agent: "senior-dev-security", when: "security bug" },
     ],
   },
   Refactor: {
-    core: ['senior-architect', 'senior-dev-reviewer', 'senior-qa'],
-    conditional: [{ agent: 'senior-developer', when: 'behavior changes' }],
+    core: ["senior-architect", "senior-dev-reviewer", "senior-qa"],
+    conditional: [{ agent: "senior-developer", when: "behavior changes" }],
   },
   Performance: {
-    core: ['senior-developer', 'senior-dba'],
-    conditional: [{ agent: 'senior-architect', when: 'structural' }],
+    core: ["senior-developer", "senior-dba"],
+    conditional: [{ agent: "senior-architect", when: "structural" }],
   },
   Security: {
-    core: ['senior-dev-security', 'senior-developer'],
-    conditional: [{ agent: 'senior-dev-reviewer', when: 'large code change' }],
+    core: ["senior-dev-security", "senior-developer"],
+    conditional: [{ agent: "senior-dev-reviewer", when: "large code change" }],
   },
-  'Business Rule': {
-    core: ['product-owner', 'senior-developer', 'senior-qa'],
-    conditional: [{ agent: 'senior-dba', when: 'data-bound' }],
+  "Business Rule": {
+    core: ["product-owner", "senior-developer", "senior-qa"],
+    conditional: [{ agent: "senior-dba", when: "data-bound" }],
   },
 };
 
@@ -158,70 +239,280 @@ export interface ContentSignal {
   ext_filter?: string[];
 }
 
-const TS_EXT = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
-const TSX_EXT = ['.ts', '.tsx', '.jsx'];
-const PY_EXT = ['.py'];
-const GO_EXT = ['.go'];
+const TS_EXT = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+const TSX_EXT = [".ts", ".tsx", ".jsx"];
+const PY_EXT = [".py"];
+const GO_EXT = [".go"];
 
 export const CONTENT_SIGNALS: ContentSignal[] = [
   // .NET / C# (existing)
-  { agent: 'senior-dba', pattern: /class\s+\w+\s*:\s*DbContext/, description: 'EF DbContext' },
-  { agent: 'senior-dba', pattern: /:\s*IRepository</, description: 'Repository pattern' },
-  { agent: 'senior-dba', pattern: /modelBuilder\.Entity</, description: 'EF model config' },
-  { agent: 'senior-dba', pattern: /\b(HasMany|HasOne|HasIndex|HasKey|HasForeignKey)\s*\(/, description: 'EF relationship' },
-  { agent: 'senior-dba', pattern: /\[Table\(/, description: 'EF Table attribute' },
-  { agent: 'senior-dba', pattern: /\b(CREATE|ALTER|DROP)\s+TABLE\b/i, description: 'DDL' },
-  { agent: 'senior-dba', pattern: /AddDbContext|UseSqlServer|UseNpgsql|UseSqlite|UseMySql/, description: 'EF provider registration' },
-  { agent: 'senior-dba', pattern: /\bSELECT\b[\s\S]{0,200}\bFROM\b/i, description: 'Raw SQL query' },
-  { agent: 'senior-dba', pattern: /\b(IDbConnection|SqlConnection|NpgsqlConnection)\b/, description: 'ADO.NET connection' },
-  { agent: 'senior-dba', pattern: /Migration|migrationBuilder\./, description: 'EF migration' },
+  {
+    agent: "senior-dba",
+    pattern: /class\s+\w+\s*:\s*DbContext/,
+    description: "EF DbContext",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /:\s*IRepository</,
+    description: "Repository pattern",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /modelBuilder\.Entity</,
+    description: "EF model config",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /\b(HasMany|HasOne|HasIndex|HasKey|HasForeignKey)\s*\(/,
+    description: "EF relationship",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /\[Table\(/,
+    description: "EF Table attribute",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /\b(CREATE|ALTER|DROP)\s+TABLE\b/i,
+    description: "DDL",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /AddDbContext|UseSqlServer|UseNpgsql|UseSqlite|UseMySql/,
+    description: "EF provider registration",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /\bSELECT\b[\s\S]{0,200}\bFROM\b/i,
+    description: "Raw SQL query",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /\b(IDbConnection|SqlConnection|NpgsqlConnection)\b/,
+    description: "ADO.NET connection",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /Migration|migrationBuilder\./,
+    description: "EF migration",
+  },
 
-  { agent: 'senior-dev-security', pattern: /\[Authorize/, description: 'Authorize attribute' },
-  { agent: 'senior-dev-security', pattern: /\[ApiController\]/, description: 'API controller' },
-  { agent: 'senior-dev-security', pattern: /\[Http(Get|Post|Put|Delete|Patch)/, description: 'HTTP endpoint' },
-  { agent: 'senior-dev-security', pattern: /\b(JwtBearer|OAuth|SignInManager|UserManager|IdentityUser)\b/, description: 'Auth surface' },
-  { agent: 'senior-dev-security', pattern: /UseAuthentication|UseAuthorization/, description: 'Auth middleware' },
-  { agent: 'senior-dev-security', pattern: /\b(BCrypt|PasswordHasher|HMACSHA|Rfc2898DeriveBytes)\b/, description: 'Crypto/password handling' },
+  {
+    agent: "senior-dev-security",
+    pattern: /\[Authorize/,
+    description: "Authorize attribute",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /\[ApiController\]/,
+    description: "API controller",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /\[Http(Get|Post|Put|Delete|Patch)/,
+    description: "HTTP endpoint",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /\b(JwtBearer|OAuth|SignInManager|UserManager|IdentityUser)\b/,
+    description: "Auth surface",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /UseAuthentication|UseAuthorization/,
+    description: "Auth middleware",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /\b(BCrypt|PasswordHasher|HMACSHA|Rfc2898DeriveBytes)\b/,
+    description: "Crypto/password handling",
+  },
 
-  { agent: 'senior-architect', pattern: /services\.Add(Scoped|Transient|Singleton)\s*</, description: 'DI registration' },
-  { agent: 'senior-architect', pattern: /WebApplication\.CreateBuilder/, description: 'Composition root' },
-  { agent: 'senior-architect', pattern: /AddMediatR|AddAutoMapper|AddFluentValidation/, description: 'Cross-cutting registration' },
-  { agent: 'senior-architect', pattern: /<Project\s+Sdk=/, description: 'csproj' },
+  {
+    agent: "senior-architect",
+    pattern: /services\.Add(Scoped|Transient|Singleton)\s*</,
+    description: "DI registration",
+  },
+  {
+    agent: "senior-architect",
+    pattern: /WebApplication\.CreateBuilder/,
+    description: "Composition root",
+  },
+  {
+    agent: "senior-architect",
+    pattern: /AddMediatR|AddAutoMapper|AddFluentValidation/,
+    description: "Cross-cutting registration",
+  },
+  {
+    agent: "senior-architect",
+    pattern: /<Project\s+Sdk=/,
+    description: "csproj",
+  },
 
-  { agent: 'senior-qa', pattern: /\[Fact\]|\[Theory\]/, description: 'xUnit test' },
-  { agent: 'senior-qa', pattern: /\[Test\]|\[TestCase\]/, description: 'NUnit test' },
-  { agent: 'senior-qa', pattern: /\b(describe|it|test)\s*\(/, description: 'JS/TS test', ext_filter: TS_EXT },
-  { agent: 'senior-qa', pattern: /Assert\.|Should\(\)|expect\s*\(/, description: 'Assertion' },
+  {
+    agent: "senior-qa",
+    pattern: /\[Fact\]|\[Theory\]/,
+    description: "xUnit test",
+  },
+  {
+    agent: "senior-qa",
+    pattern: /\[Test\]|\[TestCase\]/,
+    description: "NUnit test",
+  },
+  {
+    agent: "senior-qa",
+    pattern: /\b(describe|it|test)\s*\(/,
+    description: "JS/TS test",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-qa",
+    pattern: /Assert\.|Should\(\)|expect\s*\(/,
+    description: "Assertion",
+  },
 
-  { agent: 'senior-developer', pattern: /HttpClient|IHttpClientFactory/, description: 'HTTP client (.NET integration)' },
-  { agent: 'senior-developer', pattern: /Polly|RetryPolicy|CircuitBreaker/, description: 'Resilience policy' },
-  { agent: 'senior-developer', pattern: /ILogger<|Activity\.Current|MetricsCollector/, description: 'Observability' },
+  {
+    agent: "senior-developer",
+    pattern: /HttpClient|IHttpClientFactory/,
+    description: "HTTP client (.NET integration)",
+  },
+  {
+    agent: "senior-developer",
+    pattern: /Polly|RetryPolicy|CircuitBreaker/,
+    description: "Resilience policy",
+  },
+  {
+    agent: "senior-developer",
+    pattern: /ILogger<|Activity\.Current|MetricsCollector/,
+    description: "Observability",
+  },
 
   // TypeScript / Node
-  { agent: 'senior-developer', pattern: /from\s+['"]express['"]/, description: 'Express import', ext_filter: TS_EXT },
-  { agent: 'senior-dev-security', pattern: /\bRouter\s*\(\s*\)/, description: 'Express router', ext_filter: TS_EXT },
-  { agent: 'senior-dba', pattern: /\bprisma\.\w+\.(findFirst|findMany|findUnique|create|update|delete|upsert)\b/, description: 'Prisma client query', ext_filter: TS_EXT },
-  { agent: 'senior-dba', pattern: /from\s+['"]typeorm['"]|@Entity\s*\(/, description: 'TypeORM', ext_filter: TS_EXT },
-  { agent: 'senior-dba', pattern: /from\s+['"]sequelize['"]|sequelize\.define\s*\(/, description: 'Sequelize', ext_filter: TS_EXT },
-  { agent: 'senior-dba', pattern: /from\s+['"]mongoose['"]|mongoose\.Schema\s*\(/, description: 'Mongoose', ext_filter: TS_EXT },
-  { agent: 'senior-dev-security', pattern: /from\s+['"]bcrypt(?:js)?['"]/, description: 'bcrypt import', ext_filter: TS_EXT },
-  { agent: 'senior-dev-security', pattern: /\bpassport\.(use|authenticate)\s*\(/, description: 'Passport auth', ext_filter: TS_EXT },
-  { agent: 'senior-dev-security', pattern: /from\s+['"]jsonwebtoken['"]|\bjwt\.(sign|verify)\s*\(/, description: 'JWT', ext_filter: TS_EXT },
-  { agent: 'senior-developer', pattern: /\buseState\s*\(|\buseEffect\s*\(/, description: 'React hook', ext_filter: TSX_EXT },
-  { agent: 'senior-developer', pattern: /from\s+['"]next\//, description: 'Next.js', ext_filter: TS_EXT },
+  {
+    agent: "senior-developer",
+    pattern: /from\s+['"]express['"]/,
+    description: "Express import",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /\bRouter\s*\(\s*\)/,
+    description: "Express router",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dba",
+    pattern:
+      /\bprisma\.\w+\.(findFirst|findMany|findUnique|create|update|delete|upsert)\b/,
+    description: "Prisma client query",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dba",
+    pattern: /from\s+['"]typeorm['"]|@Entity\s*\(/,
+    description: "TypeORM",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dba",
+    pattern: /from\s+['"]sequelize['"]|sequelize\.define\s*\(/,
+    description: "Sequelize",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dba",
+    pattern: /from\s+['"]mongoose['"]|mongoose\.Schema\s*\(/,
+    description: "Mongoose",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /from\s+['"]bcrypt(?:js)?['"]/,
+    description: "bcrypt import",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /\bpassport\.(use|authenticate)\s*\(/,
+    description: "Passport auth",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /from\s+['"]jsonwebtoken['"]|\bjwt\.(sign|verify)\s*\(/,
+    description: "JWT",
+    ext_filter: TS_EXT,
+  },
+  {
+    agent: "senior-developer",
+    pattern: /\buseState\s*\(|\buseEffect\s*\(/,
+    description: "React hook",
+    ext_filter: TSX_EXT,
+  },
+  {
+    agent: "senior-developer",
+    pattern: /from\s+['"]next\//,
+    description: "Next.js",
+    ext_filter: TS_EXT,
+  },
 
   // Python
-  { agent: 'senior-dba', pattern: /from\s+sqlalchemy/, description: 'SQLAlchemy', ext_filter: PY_EXT },
-  { agent: 'senior-developer', pattern: /from\s+(django|flask|fastapi)\b/, description: 'Python web framework', ext_filter: PY_EXT },
-  { agent: 'senior-dev-security', pattern: /@app\.route|@router\.(get|post|put|delete|patch)/, description: 'Python HTTP route', ext_filter: PY_EXT },
-  { agent: 'senior-dba', pattern: /import\s+alembic|alembic\.config/, description: 'Alembic migration', ext_filter: PY_EXT },
-  { agent: 'senior-qa', pattern: /import\s+pytest|^def\s+test_/m, description: 'pytest', ext_filter: PY_EXT },
-  { agent: 'senior-qa', pattern: /import\s+unittest/, description: 'unittest', ext_filter: PY_EXT },
+  {
+    agent: "senior-dba",
+    pattern: /from\s+sqlalchemy/,
+    description: "SQLAlchemy",
+    ext_filter: PY_EXT,
+  },
+  {
+    agent: "senior-developer",
+    pattern: /from\s+(django|flask|fastapi)\b/,
+    description: "Python web framework",
+    ext_filter: PY_EXT,
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /@app\.route|@router\.(get|post|put|delete|patch)/,
+    description: "Python HTTP route",
+    ext_filter: PY_EXT,
+  },
+  {
+    agent: "senior-dba",
+    pattern: /import\s+alembic|alembic\.config/,
+    description: "Alembic migration",
+    ext_filter: PY_EXT,
+  },
+  {
+    agent: "senior-qa",
+    pattern: /import\s+pytest|^def\s+test_/m,
+    description: "pytest",
+    ext_filter: PY_EXT,
+  },
+  {
+    agent: "senior-qa",
+    pattern: /import\s+unittest/,
+    description: "unittest",
+    ext_filter: PY_EXT,
+  },
 
   // Go
-  { agent: 'senior-dba', pattern: /\bgorm\.(Open|Model|DB)\b/, description: 'GORM', ext_filter: GO_EXT },
-  { agent: 'senior-dba', pattern: /\bsqlx\.(Open|Connect|MustConnect)\b/, description: 'sqlx', ext_filter: GO_EXT },
-  { agent: 'senior-dev-security', pattern: /\bgin\.(Default|New)\b|\bchi\.(Mux|NewRouter)\b|\becho\.New\b/, description: 'Go HTTP framework', ext_filter: GO_EXT },
+  {
+    agent: "senior-dba",
+    pattern: /\bgorm\.(Open|Model|DB)\b/,
+    description: "GORM",
+    ext_filter: GO_EXT,
+  },
+  {
+    agent: "senior-dba",
+    pattern: /\bsqlx\.(Open|Connect|MustConnect)\b/,
+    description: "sqlx",
+    ext_filter: GO_EXT,
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /\bgin\.(Default|New)\b|\bchi\.(Mux|NewRouter)\b|\becho\.New\b/,
+    description: "Go HTTP framework",
+    ext_filter: GO_EXT,
+  },
 ];
 
 export interface PathHint {
@@ -231,22 +522,82 @@ export interface PathHint {
 }
 
 export const PATH_HINTS: PathHint[] = [
-  { agent: 'senior-dba', pattern: /[\\/]Migrations[\\/]/i, description: 'migrations folder' },
-  { agent: 'senior-dba', pattern: /\.(sql|psql)$/i, description: 'SQL file' },
-  { agent: 'senior-dba', pattern: /Repository\.cs$/i, description: 'Repository naming' },
-  { agent: 'senior-dba', pattern: /DbContext\.cs$/i, description: 'DbContext naming' },
-  { agent: 'senior-dba', pattern: /[\\/]models[\\/]/i, description: 'models folder' },
-  { agent: 'senior-dev-security', pattern: /Controller\.cs$/i, description: 'Controller naming' },
-  { agent: 'senior-dev-security', pattern: /[\\/]Endpoints?[\\/]/i, description: 'endpoints folder' },
-  { agent: 'senior-dev-security', pattern: /(Auth|Identity|Jwt)\w*\.cs$/i, description: 'auth file naming' },
-  { agent: 'senior-developer', pattern: /[\\/](api|handlers|middleware|services)[\\/]/i, description: 'api/handlers/middleware/services folder' },
-  { agent: 'senior-architect', pattern: /Program\.cs$|Startup\.cs$/i, description: 'composition root' },
-  { agent: 'senior-architect', pattern: /\.csproj$|Directory\.Packages\.props$/i, description: 'project boundary' },
-  { agent: 'senior-architect', pattern: /DependencyInjection\.cs$|ServiceCollectionExtensions\.cs$/i, description: 'DI extensions' },
-  { agent: 'senior-qa', pattern: /[\\/]Tests?[\\/]/i, description: 'tests folder' },
-  { agent: 'senior-qa', pattern: /\.(test|spec|tests)\.(ts|tsx|js|jsx|cs)$/i, description: 'test file naming' },
-  { agent: 'senior-qa', pattern: /_test\.go$/i, description: 'Go test file naming' },
-  { agent: 'senior-qa', pattern: /(?:^|[\\/])test_[\w-]+\.py$/i, description: 'Python pytest naming' },
+  {
+    agent: "senior-dba",
+    pattern: /[\\/]Migrations[\\/]/i,
+    description: "migrations folder",
+  },
+  { agent: "senior-dba", pattern: /\.(sql|psql)$/i, description: "SQL file" },
+  {
+    agent: "senior-dba",
+    pattern: /Repository\.cs$/i,
+    description: "Repository naming",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /DbContext\.cs$/i,
+    description: "DbContext naming",
+  },
+  {
+    agent: "senior-dba",
+    pattern: /[\\/]models[\\/]/i,
+    description: "models folder",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /Controller\.cs$/i,
+    description: "Controller naming",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /[\\/]Endpoints?[\\/]/i,
+    description: "endpoints folder",
+  },
+  {
+    agent: "senior-dev-security",
+    pattern: /(Auth|Identity|Jwt)\w*\.cs$/i,
+    description: "auth file naming",
+  },
+  {
+    agent: "senior-developer",
+    pattern: /[\\/](api|handlers|middleware|services)[\\/]/i,
+    description: "api/handlers/middleware/services folder",
+  },
+  {
+    agent: "senior-architect",
+    pattern: /Program\.cs$|Startup\.cs$/i,
+    description: "composition root",
+  },
+  {
+    agent: "senior-architect",
+    pattern: /\.csproj$|Directory\.Packages\.props$/i,
+    description: "project boundary",
+  },
+  {
+    agent: "senior-architect",
+    pattern: /DependencyInjection\.cs$|ServiceCollectionExtensions\.cs$/i,
+    description: "DI extensions",
+  },
+  {
+    agent: "senior-qa",
+    pattern: /[\\/]Tests?[\\/]/i,
+    description: "tests folder",
+  },
+  {
+    agent: "senior-qa",
+    pattern: /\.(test|spec|tests)\.(ts|tsx|js|jsx|cs)$/i,
+    description: "test file naming",
+  },
+  {
+    agent: "senior-qa",
+    pattern: /_test\.go$/i,
+    description: "Go test file naming",
+  },
+  {
+    agent: "senior-qa",
+    pattern: /(?:^|[\\/])test_[\w-]+\.py$/i,
+    description: "Python pytest naming",
+  },
 ];
 
 /**

--- a/src/tools/consolidate.ts
+++ b/src/tools/consolidate.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ToolDef } from "./registry.js";
 import { AGENT_NAMES_TUPLE } from "../config/ownership-matrix.js";
+import { scoreRubric, type RubricOutput } from "./score-rubric.js";
 
 const severity = z.enum(["Blocker", "Major", "Minor", "Suggestion"]);
 
@@ -18,10 +19,36 @@ const reportSchema = z.object({
     )
     .max(500),
   not_evaluated: z.boolean().optional().default(false),
+  /**
+   * Optional dimension score 0-100 produced by the agent. When at least one
+   * report carries a score, the consolidator emits a rubric scorecard and the
+   * verdict can be downgraded if `min_score` is supplied. Backward compatible:
+   * pre-rubric clients omit this field and behave exactly as before.
+   */
+  score: z.number().min(0).max(100).optional(),
+  score_rationale: z.string().max(2048).optional(),
 });
 
 const schema = z.object({
   reports: z.array(reportSchema).max(50),
+  /**
+   * Optional weight overrides for the rubric (sum must be 100). Forwarded to
+   * `score_rubric`. Ignored when no report carries a score.
+   */
+  weights: z
+    .record(z.enum(AGENT_NAMES_TUPLE), z.number().min(0).max(100))
+    .optional(),
+  /**
+   * Per-dimension threshold for flagging individual scores. Defaults to 75.
+   */
+  threshold: z.number().min(0).max(100).optional().default(75),
+  /**
+   * If supplied AND the weighted score is below this floor AND severity rules
+   * would otherwise return APPROVED, downgrade to CHANGES_REQUIRED. Lets a
+   * project enforce a "minimum quality bar" beyond just absence of Blockers.
+   * Independent of `threshold` (which flags individual dimensions).
+   */
+  min_score: z.number().min(0).max(100).optional(),
 });
 
 type Input = z.infer<typeof schema>;
@@ -39,6 +66,18 @@ export interface ConsolidationOutput {
   severity_counts: Record<Severity, number>;
   agents_involved: string[];
   summary: string;
+  /**
+   * Weighted-rubric scorecard if any report carried a score, else null.
+   * Independent of verdict — verdict logic preserves the legacy severity rules,
+   * extended only by the optional `min_score` floor.
+   */
+  rubric: RubricOutput | null;
+  /**
+   * True iff the verdict was downgraded from APPROVED to CHANGES_REQUIRED
+   * because the weighted score fell below `min_score`. Helps callers explain
+   * the downgrade in their output.
+   */
+  downgraded_by_score: boolean;
 }
 
 export function applyConsolidationRules(input: Input): ConsolidationOutput {
@@ -71,17 +110,58 @@ export function applyConsolidationRules(input: Input): ConsolidationOutput {
     }
   }
 
+  // Compute rubric only if at least one report carried a score. Avoids
+  // disrupting legacy callers that never opted in.
+  const scoredReports = input.reports.filter(
+    (r) => typeof r.score === "number" && !r.not_evaluated,
+  );
+  let rubric: RubricOutput | null = null;
+  if (scoredReports.length > 0) {
+    rubric = scoreRubric({
+      scores: scoredReports.map((r) => ({
+        agent: r.agent,
+        score: r.score as number,
+        rationale: r.score_rationale,
+      })),
+      weights: input.weights,
+      threshold: input.threshold,
+    });
+  }
+
+  // Severity rules (legacy, unchanged)
   let verdict: Verdict;
   if (blockers.length) verdict = "REJECTED";
   else if (majorsUnjustified.length) verdict = "REJECTED";
   else if (counts.Major + counts.Minor > 0) verdict = "CHANGES_REQUIRED";
   else verdict = "APPROVED";
 
+  // Optional score floor: APPROVED with weighted_score < min_score → CHANGES_REQUIRED.
+  // Never PROMOTES a verdict (a low score doesn't override a Blocker rejection),
+  // and never demotes below CHANGES_REQUIRED.
+  let downgradedByScore = false;
+  if (
+    typeof input.min_score === "number" &&
+    rubric !== null &&
+    verdict === "APPROVED" &&
+    rubric.weighted_score < input.min_score
+  ) {
+    verdict = "CHANGES_REQUIRED";
+    downgradedByScore = true;
+  }
+
+  const scoreSummary = rubric
+    ? ` Weighted score: ${rubric.weighted_score.toFixed(1)}/100${rubric.passes_threshold ? "" : " (below threshold)"}.`
+    : "";
+  const downgradeSummary = downgradedByScore
+    ? ` Downgraded from APPROVED to CHANGES_REQUIRED because weighted score < min_score (${input.min_score}).`
+    : "";
   const summary =
     `Verdict: ${verdict}. ` +
     `${blockers.length} blocker(s), ${majorsUnjustified.length} unjustified major(s), ` +
     `${forwarded.length} forwarded item(s), ${notEvaluated.length} agent(s) not evaluated. ` +
-    `Severity counts: ${counts.Blocker} blocker / ${counts.Major} major / ${counts.Minor} minor / ${counts.Suggestion} suggestion.`;
+    `Severity counts: ${counts.Blocker} blocker / ${counts.Major} major / ${counts.Minor} minor / ${counts.Suggestion} suggestion.` +
+    scoreSummary +
+    downgradeSummary;
 
   return {
     verdict,
@@ -92,6 +172,8 @@ export function applyConsolidationRules(input: Input): ConsolidationOutput {
     severity_counts: counts,
     agents_involved: Array.from(agentsInvolved).sort(),
     summary,
+    rubric,
+    downgraded_by_score: downgradedByScore,
   };
 }
 
@@ -100,7 +182,10 @@ export const applyConsolidationRulesTool: ToolDef<typeof schema> = {
   description:
     "Aggregate advisory reports and emit a verdict per the rules in _shared/_Severity-and-Ownership.md. " +
     "Blocker -> REJECTED. Unjustified Major -> REJECTED. Otherwise CHANGES_REQUIRED or APPROVED. " +
-    "Includes severity_counts and agents_involved for downstream summarization.",
+    "When reports carry per-dimension scores (0-100), also returns a weighted rubric scorecard " +
+    "(see score_rubric). Optional `min_score` downgrades APPROVED to CHANGES_REQUIRED if the " +
+    "weighted score is below the floor — useful for projects that want a quality bar beyond " +
+    "absence of blockers. Includes severity_counts and agents_involved for downstream summarization.",
   schema,
   handler: applyConsolidationRules,
 };

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,16 +1,21 @@
-import { z, ZodTypeAny } from 'zod';
-import { scoreRiskTool } from './score-risk.js';
-import { selectSquadTool } from './select-squad.js';
-import { sliceFilesForAgentTool } from './slice-files.js';
-import { listAgentsTool, getAgentDefinitionTool, initLocalConfigTool } from './agents.js';
-import { applyConsolidationRulesTool } from './consolidate.js';
-import { classifyWorkTypeTool } from './classify-work-type.js';
-import { detectChangedFilesTool } from './detect-changed-files.js';
-import { validatePlanTextTool } from './validate-plan-text.js';
-import { composeSquadWorkflowTool } from './compose-squad-workflow.js';
-import { composeAdvisoryBundleTool } from './compose-advisory-bundle.js';
-import { isSquadError } from '../errors.js';
-import { logger, newRequestId } from '../observability/logger.js';
+import { z, ZodTypeAny } from "zod";
+import { scoreRiskTool } from "./score-risk.js";
+import { selectSquadTool } from "./select-squad.js";
+import { sliceFilesForAgentTool } from "./slice-files.js";
+import {
+  listAgentsTool,
+  getAgentDefinitionTool,
+  initLocalConfigTool,
+} from "./agents.js";
+import { applyConsolidationRulesTool } from "./consolidate.js";
+import { scoreRubricTool } from "./score-rubric.js";
+import { classifyWorkTypeTool } from "./classify-work-type.js";
+import { detectChangedFilesTool } from "./detect-changed-files.js";
+import { validatePlanTextTool } from "./validate-plan-text.js";
+import { composeSquadWorkflowTool } from "./compose-squad-workflow.js";
+import { composeAdvisoryBundleTool } from "./compose-advisory-bundle.js";
+import { isSquadError } from "../errors.js";
+import { logger, newRequestId } from "../observability/logger.js";
 
 export interface ToolDef<T extends ZodTypeAny = ZodTypeAny> {
   name: string;
@@ -33,6 +38,7 @@ export function registerTools(): void {
   register(getAgentDefinitionTool);
   register(initLocalConfigTool);
   register(applyConsolidationRulesTool);
+  register(scoreRubricTool);
   register(classifyWorkTypeTool);
   register(detectChangedFilesTool);
   register(validatePlanTextTool);
@@ -54,22 +60,22 @@ interface ToolErrorBody {
 
 function asToolErrorResponse(body: ToolErrorBody) {
   return {
-    content: [{ type: 'text' as const, text: JSON.stringify(body, null, 2) }],
+    content: [{ type: "text" as const, text: JSON.stringify(body, null, 2) }],
     isError: true,
   };
 }
 
 function shapeOf(args: unknown): Record<string, unknown> | undefined {
-  if (args === null || typeof args !== 'object') return undefined;
+  if (args === null || typeof args !== "object") return undefined;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
     if (v === null || v === undefined) {
       out[k] = v;
     } else if (Array.isArray(v)) {
       out[k] = `[Array(${v.length})]`;
-    } else if (typeof v === 'object') {
-      out[k] = '[object]';
-    } else if (typeof v === 'string') {
+    } else if (typeof v === "object") {
+      out[k] = "[object]";
+    } else if (typeof v === "string") {
       out[k] = `[string(${v.length})]`;
     } else {
       out[k] = typeof v;
@@ -84,30 +90,34 @@ export async function dispatchTool(name: string, args: unknown) {
   const tool = tools.get(name);
 
   if (!tool) {
-    logger.warn('unknown tool', {
+    logger.warn("unknown tool", {
       tool: name,
       request_id: requestId,
-      outcome: 'unknown_tool',
+      outcome: "unknown_tool",
       duration_ms: Date.now() - started,
     });
     return asToolErrorResponse({
-      error: { code: 'UNKNOWN_TOOL', message: `unknown tool: ${name}` },
+      error: { code: "UNKNOWN_TOOL", message: `unknown tool: ${name}` },
     });
   }
 
-  logger.debug('tool call', { tool: name, request_id: requestId, input_shape: shapeOf(args) });
+  logger.debug("tool call", {
+    tool: name,
+    request_id: requestId,
+    input_shape: shapeOf(args),
+  });
 
   const parsed = tool.schema.safeParse(args);
   if (!parsed.success) {
-    logger.warn('invalid input', {
+    logger.warn("invalid input", {
       tool: name,
       request_id: requestId,
-      outcome: 'invalid_input',
+      outcome: "invalid_input",
       duration_ms: Date.now() - started,
     });
     return asToolErrorResponse({
       error: {
-        code: 'INVALID_INPUT',
+        code: "INVALID_INPUT",
         message: parsed.error.message,
         details: { issues: parsed.error.issues.length },
       },
@@ -116,22 +126,24 @@ export async function dispatchTool(name: string, args: unknown) {
 
   try {
     const result = await tool.handler(parsed.data);
-    logger.info('tool ok', {
+    logger.info("tool ok", {
       tool: name,
       request_id: requestId,
-      outcome: 'success',
+      outcome: "success",
       duration_ms: Date.now() - started,
     });
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      content: [
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ],
     };
   } catch (err) {
     const duration_ms = Date.now() - started;
     if (isSquadError(err)) {
-      logger.warn('tool error', {
+      logger.warn("tool error", {
         tool: name,
         request_id: requestId,
-        outcome: 'tool_error',
+        outcome: "tool_error",
         duration_ms,
         error_code: err.code,
       });
@@ -140,15 +152,15 @@ export async function dispatchTool(name: string, args: unknown) {
       });
     }
     const message = err instanceof Error ? err.message : String(err);
-    logger.error('internal error', {
+    logger.error("internal error", {
       tool: name,
       request_id: requestId,
-      outcome: 'internal_error',
+      outcome: "internal_error",
       duration_ms,
       details: { message },
     });
     return asToolErrorResponse({
-      error: { code: 'INTERNAL_ERROR', message: 'internal tool error' },
+      error: { code: "INTERNAL_ERROR", message: "internal tool error" },
     });
   }
 }
@@ -162,15 +174,23 @@ function zodToJsonSchema(schema: ZodTypeAny): Record<string, unknown> {
       properties[key] = zodToJsonSchema(value);
       if (!value.isOptional()) required.push(key);
     }
-    return { type: 'object', properties, ...(required.length ? { required } : {}) };
+    return {
+      type: "object",
+      properties,
+      ...(required.length ? { required } : {}),
+    };
   }
-  if (schema instanceof z.ZodString) return { type: 'string' };
-  if (schema instanceof z.ZodNumber) return { type: 'number' };
-  if (schema instanceof z.ZodBoolean) return { type: 'boolean' };
-  if (schema instanceof z.ZodArray) return { type: 'array', items: zodToJsonSchema(schema.element) };
-  if (schema instanceof z.ZodEnum) return { type: 'string', enum: schema.options };
+  if (schema instanceof z.ZodString) return { type: "string" };
+  if (schema instanceof z.ZodNumber) return { type: "number" };
+  if (schema instanceof z.ZodBoolean) return { type: "boolean" };
+  if (schema instanceof z.ZodArray)
+    return { type: "array", items: zodToJsonSchema(schema.element) };
+  if (schema instanceof z.ZodEnum)
+    return { type: "string", enum: schema.options };
   if (schema instanceof z.ZodOptional) return zodToJsonSchema(schema.unwrap());
-  if (schema instanceof z.ZodDefault) return zodToJsonSchema(schema.removeDefault());
-  if (schema instanceof z.ZodEffects) return zodToJsonSchema(schema.innerType());
+  if (schema instanceof z.ZodDefault)
+    return zodToJsonSchema(schema.removeDefault());
+  if (schema instanceof z.ZodEffects)
+    return zodToJsonSchema(schema.innerType());
   return {};
 }

--- a/src/tools/score-rubric.ts
+++ b/src/tools/score-rubric.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+import type { ToolDef } from "./registry.js";
+import {
+  AGENT_NAMES_TUPLE,
+  AGENTS,
+  DEFAULT_RUBRIC_WEIGHTS,
+  type AgentName,
+} from "../config/ownership-matrix.js";
+
+/**
+ * Per-agent dimension score from an advisory pass. Scores are 0-100 (higher is
+ * better). Reports without a score (e.g. legacy clients, unsupported agents,
+ * `not_evaluated: true`) are simply omitted from the rubric.
+ */
+const dimensionScoreSchema = z.object({
+  agent: z.enum(AGENT_NAMES_TUPLE),
+  score: z.number().min(0).max(100),
+  rationale: z.string().max(2048).optional(),
+});
+
+/**
+ * Repo override of weights. Keys are agent names; values 0-100. The set of
+ * supplied keys must sum to 100 (validated). Agents absent from this object
+ * fall back to DEFAULT_RUBRIC_WEIGHTS for that name. Useful when a project
+ * wants to ignore a dimension entirely (set its weight to 0 and redistribute).
+ */
+const weightOverridesSchema = z
+  .record(z.enum(AGENT_NAMES_TUPLE), z.number().min(0).max(100))
+  .optional();
+
+const schema = z.object({
+  scores: z.array(dimensionScoreSchema).max(50),
+  weights: weightOverridesSchema,
+  threshold: z.number().min(0).max(100).optional().default(75),
+});
+
+type Input = z.infer<typeof schema>;
+
+export interface DimensionEntry {
+  agent: AgentName;
+  dimension: string;
+  score: number;
+  weight: number;
+  contribution: number;
+  rationale?: string;
+  below_threshold: boolean;
+}
+
+export interface RubricOutput {
+  weighted_score: number;
+  threshold: number;
+  passes_threshold: boolean;
+  dimensions: DimensionEntry[];
+  ignored_agents: string[];
+  weights_source: "default" | "override";
+  scorecard_text: string;
+}
+
+const BAR_WIDTH = 20;
+
+function renderBar(score: number): string {
+  const filled = Math.round((score / 100) * BAR_WIDTH);
+  return "█".repeat(filled) + "░".repeat(BAR_WIDTH - filled);
+}
+
+function formatScorecard(out: Omit<RubricOutput, "scorecard_text">): string {
+  const header = `SQUAD RUBRIC — weighted ${out.weighted_score.toFixed(1)} / 100 (threshold ${out.threshold})`;
+  const verdictLine = out.passes_threshold ? "PASS" : "BELOW THRESHOLD";
+  const lines = out.dimensions.map((d) => {
+    const flag = d.below_threshold ? " ⚠" : "  ";
+    const dim = d.dimension.padEnd(20);
+    const bar = renderBar(d.score);
+    const score = String(d.score).padStart(3);
+    const weight = `×${d.weight.toString().padStart(2)}%`;
+    return `${dim} ${bar}  ${score}  ${weight}  ${d.agent}${flag}`;
+  });
+  return [header, "─".repeat(70), ...lines, "─".repeat(70), verdictLine].join(
+    "\n",
+  );
+}
+
+/**
+ * Compute the weighted-rubric scorecard from per-agent dimension scores.
+ *
+ * Math:
+ *   - Reduce supplied scores to the subset of agents present.
+ *   - Resolve weights: override (if provided AND keys sum to 100) > default.
+ *   - For each scored agent, contribution = score * weight / 100.
+ *   - weighted_score = sum of contributions normalised so weights sum to 100
+ *     across the agents that ACTUALLY scored. (If only 6 of 9 agents scored,
+ *     the rubric renormalises across those 6 instead of leaving 3 dimensions
+ *     contributing 0 to the weighted average.)
+ *   - Dimensions below `threshold` are flagged.
+ *
+ * Returns a RubricOutput; meta-agents (weight 0) and unscored agents are listed
+ * in `ignored_agents`.
+ */
+export function scoreRubric(input: Input): RubricOutput {
+  const overrides = input.weights;
+  let weights: Record<AgentName, number>;
+  let weightsSource: "default" | "override";
+
+  if (overrides && Object.keys(overrides).length > 0) {
+    const overrideSum = Object.values(overrides).reduce((acc, v) => acc + v, 0);
+    if (Math.abs(overrideSum - 100) > 0.01) {
+      throw new Error(
+        `weights override must sum to 100, got ${overrideSum}. Supplied: ${JSON.stringify(overrides)}`,
+      );
+    }
+    weights = { ...DEFAULT_RUBRIC_WEIGHTS, ...overrides } as Record<
+      AgentName,
+      number
+    >;
+    weightsSource = "override";
+  } else {
+    weights = { ...DEFAULT_RUBRIC_WEIGHTS };
+    weightsSource = "default";
+  }
+
+  // Build the dimension list from scores actually supplied.
+  const scoredAgents = new Set(input.scores.map((s) => s.agent));
+  const ignored: string[] = [];
+  for (const agentName of AGENT_NAMES_TUPLE) {
+    if (!scoredAgents.has(agentName)) {
+      // Either unscored OR weight 0 (meta-agent). Both go to ignored, distinguished by weight.
+      ignored.push(agentName);
+    }
+  }
+
+  // Effective weight base: sum of weights across agents that actually scored AND have weight > 0.
+  // We renormalise to this base so the weighted score reflects only the dimensions evaluated.
+  let weightBase = 0;
+  for (const s of input.scores) {
+    weightBase += weights[s.agent] ?? 0;
+  }
+
+  const dimensions: DimensionEntry[] = [];
+  let weightedScore = 0;
+
+  if (weightBase > 0) {
+    for (const s of input.scores) {
+      const w = weights[s.agent] ?? 0;
+      if (w === 0) {
+        // Meta-agent that somehow emitted a score — ignore from rubric, surface in ignored.
+        if (!ignored.includes(s.agent)) ignored.push(s.agent);
+        continue;
+      }
+      const normalisedWeight = (w / weightBase) * 100;
+      const contribution = (s.score * normalisedWeight) / 100;
+      dimensions.push({
+        agent: s.agent,
+        dimension: AGENTS[s.agent].dimension,
+        score: s.score,
+        weight: Math.round(normalisedWeight * 10) / 10,
+        contribution: Math.round(contribution * 10) / 10,
+        rationale: s.rationale,
+        below_threshold: s.score < input.threshold,
+      });
+      weightedScore += contribution;
+    }
+  }
+
+  weightedScore = Math.round(weightedScore * 10) / 10;
+
+  // Sort dimensions by descending weight so the most important come first.
+  dimensions.sort((a, b) => b.weight - a.weight);
+
+  const partial: Omit<RubricOutput, "scorecard_text"> = {
+    weighted_score: weightedScore,
+    threshold: input.threshold,
+    passes_threshold: weightedScore >= input.threshold,
+    dimensions,
+    ignored_agents: ignored,
+    weights_source: weightsSource,
+  };
+
+  return { ...partial, scorecard_text: formatScorecard(partial) };
+}
+
+export const scoreRubricTool: ToolDef<typeof schema> = {
+  name: "score_rubric",
+  description:
+    "Compute a weighted multi-dimensional rubric scorecard from per-agent advisory scores (0-100). " +
+    "Each agent represents one dimension (Architecture, Security, Testing, etc.) with a default weight; " +
+    "weights can be overridden per-repo via .squad.yaml. Returns weighted_score, per-dimension breakdown, " +
+    "pass/fail vs threshold (default 75), and a pre-formatted ASCII scorecard. " +
+    "Renormalises across agents that actually scored, so a partial advisory pass produces a meaningful score.",
+  schema,
+  handler: scoreRubric,
+};

--- a/tests/consolidate-rubric.test.ts
+++ b/tests/consolidate-rubric.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import { applyConsolidationRules } from "../src/tools/consolidate.js";
+
+describe("apply_consolidation_rules — backward compat (no scores)", () => {
+  it("returns rubric=null when no report carries a score", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [],
+          not_evaluated: false,
+        },
+      ],
+      threshold: 75,
+    });
+    expect(out.rubric).toBeNull();
+    expect(out.downgraded_by_score).toBe(false);
+    expect(out.verdict).toBe("APPROVED");
+  });
+
+  it("preserves legacy verdict logic exactly when no scores supplied", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-dev-security",
+          findings: [
+            { severity: "Blocker", title: "auth bypass", justified: false },
+          ],
+          not_evaluated: false,
+        },
+      ],
+      threshold: 75,
+    });
+    expect(out.verdict).toBe("REJECTED");
+    expect(out.rubric).toBeNull();
+  });
+});
+
+describe("apply_consolidation_rules — with rubric scores", () => {
+  it("emits a rubric when scores are supplied", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [],
+          not_evaluated: false,
+          score: 85,
+        },
+        {
+          agent: "senior-dev-security",
+          findings: [],
+          not_evaluated: false,
+          score: 70,
+        },
+      ],
+      threshold: 75,
+    });
+    expect(out.rubric).not.toBeNull();
+    expect(out.rubric!.dimensions).toHaveLength(2);
+    expect(out.rubric!.weighted_score).toBe(77.5); // (85+70)/2 — equal default weights
+  });
+
+  it("does NOT downgrade APPROVED when min_score is omitted", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [],
+          not_evaluated: false,
+          score: 40, // very low
+        },
+      ],
+      threshold: 75,
+    });
+    expect(out.verdict).toBe("APPROVED");
+    expect(out.downgraded_by_score).toBe(false);
+  });
+
+  it("downgrades APPROVED to CHANGES_REQUIRED when score < min_score", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [],
+          not_evaluated: false,
+          score: 40,
+        },
+      ],
+      threshold: 75,
+      min_score: 60,
+    });
+    expect(out.verdict).toBe("CHANGES_REQUIRED");
+    expect(out.downgraded_by_score).toBe(true);
+    expect(out.summary).toMatch(/Downgraded/);
+  });
+
+  it("does not downgrade if verdict is already non-APPROVED", () => {
+    // Even though score is low, verdict is REJECTED for an unjustified Major.
+    // downgraded_by_score must remain false (we never downgrade further).
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [
+            { severity: "Major", title: "tight coupling", justified: false },
+          ],
+          not_evaluated: false,
+          score: 40,
+        },
+      ],
+      threshold: 75,
+      min_score: 80,
+    });
+    expect(out.verdict).toBe("REJECTED");
+    expect(out.downgraded_by_score).toBe(false);
+  });
+
+  it("preserves verdict when score is at or above min_score", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [],
+          not_evaluated: false,
+          score: 80,
+        },
+      ],
+      threshold: 75,
+      min_score: 75,
+    });
+    expect(out.verdict).toBe("APPROVED");
+    expect(out.downgraded_by_score).toBe(false);
+  });
+
+  it("summary includes weighted score line when rubric present", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [],
+          not_evaluated: false,
+          score: 88,
+        },
+      ],
+      threshold: 75,
+    });
+    expect(out.summary).toMatch(/Weighted score: 88\.0\/100/);
+  });
+
+  it("skips reports flagged not_evaluated even if they carry a score", () => {
+    const out = applyConsolidationRules({
+      reports: [
+        {
+          agent: "senior-architect",
+          findings: [],
+          not_evaluated: true, // skip
+          score: 30, // would tank the score if not skipped
+        },
+        {
+          agent: "senior-dev-security",
+          findings: [],
+          not_evaluated: false,
+          score: 90,
+        },
+      ],
+      threshold: 75,
+    });
+    expect(out.rubric!.dimensions).toHaveLength(1);
+    expect(out.rubric!.weighted_score).toBe(90);
+  });
+});

--- a/tests/integration/server-lifecycle.test.ts
+++ b/tests/integration/server-lifecycle.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { spawnServer, initialize, type ServerHandle } from './stdio-helpers.js';
+import { describe, it, expect, afterEach } from "vitest";
+import { spawnServer, initialize, type ServerHandle } from "./stdio-helpers.js";
 
 let handle: ServerHandle | null = null;
 
@@ -8,38 +8,41 @@ afterEach(async () => {
   handle = null;
 });
 
-describe('server lifecycle', () => {
-  it('initializes, lists tools, calls a tool, closes cleanly', async () => {
+describe("server lifecycle", () => {
+  it("initializes, lists tools, calls a tool, closes cleanly", async () => {
     handle = await spawnServer();
     const initRes = await initialize(handle, 1);
     expect(initRes.id).toBe(1);
-    expect((initRes.result as { protocolVersion?: string }).protocolVersion).toBeTruthy();
+    expect(
+      (initRes.result as { protocolVersion?: string }).protocolVersion,
+    ).toBeTruthy();
 
-    handle.send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+    handle.send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
     const toolsRes = await handle.recv(2);
     const tools = (toolsRes.result as { tools: { name: string }[] }).tools;
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
-      'apply_consolidation_rules',
-      'classify_work_type',
-      'compose_advisory_bundle',
-      'compose_squad_workflow',
-      'detect_changed_files',
-      'get_agent_definition',
-      'init_local_config',
-      'list_agents',
-      'score_risk',
-      'select_squad',
-      'slice_files_for_agent',
-      'validate_plan_text',
+      "apply_consolidation_rules",
+      "classify_work_type",
+      "compose_advisory_bundle",
+      "compose_squad_workflow",
+      "detect_changed_files",
+      "get_agent_definition",
+      "init_local_config",
+      "list_agents",
+      "score_risk",
+      "score_rubric",
+      "select_squad",
+      "slice_files_for_agent",
+      "validate_plan_text",
     ]);
 
     handle.send({
-      jsonrpc: '2.0',
+      jsonrpc: "2.0",
       id: 3,
-      method: 'tools/call',
+      method: "tools/call",
       params: {
-        name: 'score_risk',
+        name: "score_risk",
         arguments: {
           touches_auth: true,
           touches_money: true,
@@ -51,50 +54,61 @@ describe('server lifecycle', () => {
       },
     });
     const callRes = await handle.recv(3);
-    const text = ((callRes.result as { content: { text: string }[] }).content)[0]!.text;
+    const text = (callRes.result as { content: { text: string }[] }).content[0]!
+      .text;
     const parsed = JSON.parse(text) as { level: string };
-    expect(parsed.level).toBe('High');
+    expect(parsed.level).toBe("High");
   }, 15_000);
 
-  it('lists resources and prompts', async () => {
+  it("lists resources and prompts", async () => {
     handle = await spawnServer();
     await initialize(handle, 1);
 
-    handle.send({ jsonrpc: '2.0', id: 2, method: 'resources/list' });
+    handle.send({ jsonrpc: "2.0", id: 2, method: "resources/list" });
     const resRes = await handle.recv(2);
     const resources = (resRes.result as { resources: unknown[] }).resources;
     expect(resources.length).toBeGreaterThanOrEqual(9);
 
-    handle.send({ jsonrpc: '2.0', id: 3, method: 'prompts/list' });
+    handle.send({ jsonrpc: "2.0", id: 3, method: "prompts/list" });
     const promptsRes = await handle.recv(3);
-    const prompts = (promptsRes.result as { prompts: { name: string }[] }).prompts;
+    const prompts = (promptsRes.result as { prompts: { name: string }[] })
+      .prompts;
     const promptNames = prompts.map((p) => p.name).sort();
-    expect(promptNames).toEqual(['agent_advisory', 'consolidator', 'squad_orchestration']);
+    expect(promptNames).toEqual([
+      "agent_advisory",
+      "consolidator",
+      "squad_orchestration",
+    ]);
   }, 15_000);
 
-  it('select_squad with cross-stack fixtures emits expected agents', async () => {
+  it("select_squad with cross-stack fixtures emits expected agents", async () => {
     handle = await spawnServer();
     await initialize(handle, 1);
 
     handle.send({
-      jsonrpc: '2.0',
+      jsonrpc: "2.0",
       id: 2,
-      method: 'tools/call',
+      method: "tools/call",
       params: {
-        name: 'select_squad',
+        name: "select_squad",
         arguments: {
-          work_type: 'Feature',
-          files: ['tests/fixtures/express.ts', 'tests/fixtures/fastapi.py', 'tests/fixtures/gin.go'],
+          work_type: "Feature",
+          files: [
+            "tests/fixtures/express.ts",
+            "tests/fixtures/fastapi.py",
+            "tests/fixtures/gin.go",
+          ],
           read_content: true,
           workspace_root: process.cwd(),
         },
       },
     });
     const callRes = await handle.recv(2);
-    const text = ((callRes.result as { content: { text: string }[] }).content)[0]!.text;
+    const text = (callRes.result as { content: { text: string }[] }).content[0]!
+      .text;
     const parsed = JSON.parse(text) as { agents: string[] };
-    expect(parsed.agents).toContain('senior-dev-security');
-    expect(parsed.agents).toContain('senior-dba');
-    expect(parsed.agents).toContain('senior-developer');
+    expect(parsed.agents).toContain("senior-dev-security");
+    expect(parsed.agents).toContain("senior-dba");
+    expect(parsed.agents).toContain("senior-developer");
   }, 15_000);
 });

--- a/tests/score-rubric.test.ts
+++ b/tests/score-rubric.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { scoreRubric } from "../src/tools/score-rubric.js";
+import { DEFAULT_RUBRIC_WEIGHTS } from "../src/config/ownership-matrix.js";
+
+describe("score_rubric — defaults", () => {
+  it("returns a rubric when at least one score is supplied", () => {
+    const out = scoreRubric({
+      scores: [{ agent: "senior-architect", score: 80 }],
+      threshold: 75,
+    });
+    expect(out.dimensions).toHaveLength(1);
+    expect(out.dimensions[0].agent).toBe("senior-architect");
+    expect(out.weighted_score).toBe(80);
+    expect(out.passes_threshold).toBe(true);
+    expect(out.weights_source).toBe("default");
+    expect(out.scorecard_text).toContain("Architecture");
+  });
+
+  it("renormalises weights across only the agents that scored", () => {
+    // Architect (18) and Security (18) — equal default weights, so renormalised
+    // to 50% each. Weighted score = (80 + 60) / 2 = 70.
+    const out = scoreRubric({
+      scores: [
+        { agent: "senior-architect", score: 80 },
+        { agent: "senior-dev-security", score: 60 },
+      ],
+      threshold: 75,
+    });
+    expect(out.weighted_score).toBe(70);
+    expect(out.dimensions).toHaveLength(2);
+    // Each gets renormalised to 50%
+    for (const d of out.dimensions) {
+      expect(d.weight).toBeCloseTo(50, 0);
+    }
+  });
+
+  it("flags dimensions below the threshold", () => {
+    const out = scoreRubric({
+      scores: [
+        { agent: "senior-architect", score: 90 },
+        { agent: "senior-dev-security", score: 50 },
+      ],
+      threshold: 75,
+    });
+    const sec = out.dimensions.find((d) => d.agent === "senior-dev-security");
+    const arch = out.dimensions.find((d) => d.agent === "senior-architect");
+    expect(sec?.below_threshold).toBe(true);
+    expect(arch?.below_threshold).toBe(false);
+  });
+
+  it("lists agents without scores in ignored_agents", () => {
+    const out = scoreRubric({
+      scores: [{ agent: "senior-architect", score: 80 }],
+      threshold: 75,
+    });
+    expect(out.ignored_agents).toContain("senior-dba");
+    expect(out.ignored_agents).toContain("senior-developer");
+    expect(out.ignored_agents).toContain("product-owner");
+    expect(out.ignored_agents).toContain("tech-lead-planner"); // meta-agent
+    expect(out.ignored_agents).not.toContain("senior-architect");
+  });
+
+  it("ignores meta-agents that somehow emit a score", () => {
+    // tech-lead-consolidator has weight 0 — must not contribute to weighted score.
+    const out = scoreRubric({
+      scores: [
+        { agent: "senior-architect", score: 80 },
+        { agent: "tech-lead-consolidator", score: 95 }, // would skew if included
+      ],
+      threshold: 75,
+    });
+    expect(out.weighted_score).toBe(80);
+    expect(out.ignored_agents).toContain("tech-lead-consolidator");
+    expect(
+      out.dimensions.find((d) => d.agent === "tech-lead-consolidator"),
+    ).toBeUndefined();
+  });
+
+  it("produces zero-score output when all supplied scores are meta-agents", () => {
+    const out = scoreRubric({
+      scores: [{ agent: "tech-lead-planner", score: 90 }],
+      threshold: 75,
+    });
+    expect(out.weighted_score).toBe(0);
+    expect(out.dimensions).toHaveLength(0);
+    expect(out.passes_threshold).toBe(false);
+  });
+
+  it("passes the threshold flag honestly", () => {
+    const lowScore = scoreRubric({
+      scores: [{ agent: "senior-architect", score: 70 }],
+      threshold: 75,
+    });
+    expect(lowScore.passes_threshold).toBe(false);
+
+    const exact = scoreRubric({
+      scores: [{ agent: "senior-architect", score: 75 }],
+      threshold: 75,
+    });
+    expect(exact.passes_threshold).toBe(true);
+  });
+});
+
+describe("score_rubric — weights override", () => {
+  it("honours explicit weights that sum to 100", () => {
+    // Force Security to 50%, Architecture to 50% — equal weight, scores 60 and 80.
+    // Both ARE in the override and DO have scores, so renormalisation is a no-op.
+    const out = scoreRubric({
+      scores: [
+        { agent: "senior-architect", score: 80 },
+        { agent: "senior-dev-security", score: 60 },
+      ],
+      weights: {
+        "senior-architect": 50,
+        "senior-dev-security": 50,
+        "product-owner": 0,
+        "tech-lead-planner": 0,
+        "tech-lead-consolidator": 0,
+        "senior-dba": 0,
+        "senior-developer": 0,
+        "senior-dev-reviewer": 0,
+        "senior-qa": 0,
+      },
+      threshold: 75,
+    });
+    expect(out.weights_source).toBe("override");
+    expect(out.weighted_score).toBe(70);
+  });
+
+  it("rejects override that does not sum to 100", () => {
+    expect(() =>
+      scoreRubric({
+        scores: [{ agent: "senior-architect", score: 80 }],
+        weights: {
+          "senior-architect": 50,
+          "senior-dev-security": 30,
+          "product-owner": 0,
+          "tech-lead-planner": 0,
+          "tech-lead-consolidator": 0,
+          "senior-dba": 0,
+          "senior-developer": 0,
+          "senior-dev-reviewer": 0,
+          "senior-qa": 0,
+        },
+        threshold: 75,
+      }),
+    ).toThrow(/sum to 100/);
+  });
+});
+
+describe("score_rubric — defaults sanity", () => {
+  it("default weights sum to 100 across advisory agents", () => {
+    const sum = Object.values(DEFAULT_RUBRIC_WEIGHTS).reduce(
+      (a, b) => a + b,
+      0,
+    );
+    expect(sum).toBe(100);
+  });
+
+  it("meta-agents have weight 0", () => {
+    expect(DEFAULT_RUBRIC_WEIGHTS["tech-lead-planner"]).toBe(0);
+    expect(DEFAULT_RUBRIC_WEIGHTS["tech-lead-consolidator"]).toBe(0);
+  });
+});
+
+describe("score_rubric — scorecard rendering", () => {
+  it("includes header, threshold, and PASS/BELOW THRESHOLD verdict line", () => {
+    const out = scoreRubric({
+      scores: [{ agent: "senior-architect", score: 80 }],
+      threshold: 75,
+    });
+    expect(out.scorecard_text).toMatch(/SQUAD RUBRIC/);
+    expect(out.scorecard_text).toMatch(/threshold 75/);
+    expect(out.scorecard_text).toMatch(/PASS/);
+  });
+
+  it("flags below-threshold dimensions in the scorecard", () => {
+    const out = scoreRubric({
+      scores: [{ agent: "senior-dev-security", score: 50 }],
+      threshold: 75,
+    });
+    expect(out.scorecard_text).toMatch(/⚠/);
+    expect(out.scorecard_text).toMatch(/BELOW THRESHOLD/);
+  });
+});

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -1,20 +1,20 @@
-import { spawn } from 'node:child_process';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const serverPath = path.resolve(here, '..', 'dist', 'index.js');
+const serverPath = path.resolve(here, "..", "dist", "index.js");
 
 const child = spawn(process.execPath, [serverPath], {
-  stdio: ['pipe', 'pipe', 'inherit'],
+  stdio: ["pipe", "pipe", "inherit"],
 });
 
-let buf = '';
+let buf = "";
 const messages = [];
-child.stdout.on('data', (chunk) => {
-  buf += chunk.toString('utf8');
+child.stdout.on("data", (chunk) => {
+  buf += chunk.toString("utf8");
   let idx;
-  while ((idx = buf.indexOf('\n')) !== -1) {
+  while ((idx = buf.indexOf("\n")) !== -1) {
     const line = buf.slice(0, idx).trim();
     buf = buf.slice(idx + 1);
     if (line) {
@@ -28,7 +28,7 @@ child.stdout.on('data', (chunk) => {
 });
 
 function send(req) {
-  child.stdin.write(JSON.stringify(req) + '\n');
+  child.stdin.write(JSON.stringify(req) + "\n");
 }
 
 function waitFor(id, timeoutMs = 3000) {
@@ -50,69 +50,83 @@ function waitFor(id, timeoutMs = 3000) {
 let exitCode = 0;
 try {
   send({
-    jsonrpc: '2.0',
+    jsonrpc: "2.0",
     id: 1,
-    method: 'initialize',
-    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'smoke', version: '0.0' } },
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "smoke", version: "0.0" },
+    },
   });
   await waitFor(1);
 
-  send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+  send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
   const toolsRes = await waitFor(2);
   const toolNames = toolsRes.result.tools.map((t) => t.name).sort();
-  console.log('tools:', toolNames.join(', '));
+  console.log("tools:", toolNames.join(", "));
   const expected = [
-    'apply_consolidation_rules',
-    'classify_work_type',
-    'compose_advisory_bundle',
-    'compose_squad_workflow',
-    'detect_changed_files',
-    'get_agent_definition',
-    'init_local_config',
-    'list_agents',
-    'score_risk',
-    'select_squad',
-    'slice_files_for_agent',
-    'validate_plan_text',
+    "apply_consolidation_rules",
+    "classify_work_type",
+    "compose_advisory_bundle",
+    "compose_squad_workflow",
+    "detect_changed_files",
+    "get_agent_definition",
+    "init_local_config",
+    "list_agents",
+    "score_risk",
+    "score_rubric",
+    "select_squad",
+    "slice_files_for_agent",
+    "validate_plan_text",
   ];
   for (const e of expected) {
     if (!toolNames.includes(e)) throw new Error(`missing tool: ${e}`);
   }
   if (toolNames.length !== expected.length) {
-    throw new Error(`tool count mismatch: ${toolNames.length} vs ${expected.length}`);
+    throw new Error(
+      `tool count mismatch: ${toolNames.length} vs ${expected.length}`,
+    );
   }
 
   send({
-    jsonrpc: '2.0',
+    jsonrpc: "2.0",
     id: 3,
-    method: 'tools/call',
+    method: "tools/call",
     params: {
-      name: 'score_risk',
-      arguments: { touches_auth: true, touches_money: true, touches_migration: true, files_count: 10 },
+      name: "score_risk",
+      arguments: {
+        touches_auth: true,
+        touches_money: true,
+        touches_migration: true,
+        files_count: 10,
+      },
     },
   });
   const callRes = await waitFor(3);
   const text = callRes.result.content[0].text;
   const parsed = JSON.parse(text);
-  if (parsed.level !== 'High') throw new Error(`expected High, got ${parsed.level}`);
-  console.log('score_risk High ok, score=', parsed.score);
+  if (parsed.level !== "High")
+    throw new Error(`expected High, got ${parsed.level}`);
+  console.log("score_risk High ok, score=", parsed.score);
 
-  send({ jsonrpc: '2.0', id: 4, method: 'resources/list' });
+  send({ jsonrpc: "2.0", id: 4, method: "resources/list" });
   const resRes = await waitFor(4);
-  console.log('resources count:', resRes.result.resources.length);
-  if (resRes.result.resources.length < 9) throw new Error('expected at least 9 agent resources');
+  console.log("resources count:", resRes.result.resources.length);
+  if (resRes.result.resources.length < 9)
+    throw new Error("expected at least 9 agent resources");
 
-  send({ jsonrpc: '2.0', id: 5, method: 'prompts/list' });
+  send({ jsonrpc: "2.0", id: 5, method: "prompts/list" });
   const promptsRes = await waitFor(5);
   const promptNames = promptsRes.result.prompts.map((p) => p.name).sort();
-  console.log('prompts:', promptNames.join(', '));
-  for (const p of ['agent_advisory', 'consolidator', 'squad_orchestration']) {
+  console.log("prompts:", promptNames.join(", "));
+  for (const p of ["agent_advisory", "consolidator", "squad_orchestration"]) {
     if (!promptNames.includes(p)) throw new Error(`missing prompt: ${p}`);
   }
 
-  console.log('SMOKE OK');
+  console.log("SMOKE OK");
 } catch (err) {
-  console.error('SMOKE FAILED:', err.message);
+  console.error("SMOKE FAILED:", err.message);
   exitCode = 1;
 } finally {
   child.kill();


### PR DESCRIPTION
Each advisory agent now represents a dimension of a multi-dimensional rubric with a default weight. The consolidator emits a pre-formatted ASCII scorecard alongside the legacy verdict, giving a visible, auditable, defensible signal that distinguishes the squad from generic AI reviewers.

Why this is the highest-impact feature for the project right now:
- The deterministic routing + slicing-by-jurisdiction is what makes the squad unique, but it was invisible. The scorecard makes it visible.
- Weighted, transparent rubric per dimension is a gap in the AI code review market (per "AI Code Reviews Are Broken By Default", Mar/2026). Confidence scores from competitors (CodeRabbit, the official Anthropic plugin) lump everything into one number.
- Every advisory pass now produces a comparable score across PRs, enabling later features (cross-PR learning, threshold tuning) to compose on top.

ADDED

- src/tools/score-rubric.ts — pure function. Inputs: per-agent scores (0-100), optional weights override, optional threshold. Outputs: weighted_score, per-dimension breakdown with ASCII bars, passes_threshold, ignored_agents, and a pre-formatted scorecard_text. Renormalises across agents that actually scored — a partial advisory still produces a meaningful score.
- AgentDef extended with weight + dimension. Default weights sum to 100 across the seven advisory agents:
    Architecture       senior-architect       18%
    Security           senior-dev-security    18%
    Application Code   senior-developer       18%
    Data Layer         senior-dba             14%
    Testing & QA       senior-qa              14%
    Code Quality       senior-dev-reviewer    10%
    Business & UX      product-owner           8%
  Meta-agents (tech-lead-planner, tech-lead-consolidator) carry weight 0 —
  they do not score a dimension.
- DEFAULT_RUBRIC_WEIGHTS exported for clean override merging.
- apply_consolidation_rules now accepts optional per-agent score and
  score_rationale, optional weights override, threshold, and min_score.
  Returns rubric: RubricOutput | null and downgraded_by_score: boolean.
  When min_score is set and the weighted score falls below the floor, an
  otherwise-APPROVED verdict is downgraded to CHANGES_REQUIRED. Never
  promotes a verdict; never demotes below CHANGES_REQUIRED.
- Each advisory agent .md ships a ## Score section: protocol for emitting
  Score: NN/100 + a per-dimension calibration table
  (90-100 / 70-89 / 50-69 / 30-49 / 0-29 bands).
- skills/squad/SKILL.md captures per-agent scores into the reports array,
  passes them to apply_consolidation_rules, and surfaces
  rubric.scorecard_text verbatim in the final output.

TESTS

- tests/score-rubric.test.ts — math correctness (renormalisation, weight overrides, sum=100 validation, threshold edge cases, meta-agent ignore, scorecard rendering).
- tests/consolidate-rubric.test.ts — backward compat (no scores → rubric null, legacy verdict preserved), score propagation, min_score downgrade honours all three rules (no-promotion, no-double-demotion, exact bound).
- tests/integration/server-lifecycle.test.ts and tests/smoke.mjs updated for the new score_rubric tool registration.

Backward compatible. Pre-rubric callers (no score in any report) get the exact same output shape and verdict logic as before.

Tests: 172 passing, 3 skipped. Smoke test passes.