### PR TITLE
fix(release): bump marketplace.json to 0.6.2 + harden release version checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "ggemba/squad-mcp"
       },
       "description": "Squad-dev workflow: deterministic classification, risk scoring, agent selection, advisory orchestration over MCP, native subagents, plus /squad and /squad-review slash commands.",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "homepage": "https://github.com/ggemba/squad-mcp"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "squad",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Squad-dev workflow as a Claude Code plugin: classification, risk scoring, agent selection, advisory orchestration. Bundles an MCP server, native subagents, and the /squad and /squad-review slash commands.",
   "license": "Apache-2.0",
   "author": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   push:
-    tags: ['v*.*.*']
+    tags: ["v*.*.*"]
 
 permissions:
   contents: read
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -25,12 +25,24 @@ jobs:
       - name: verify version matches tag
         shell: bash
         run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          PLUGIN_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+          MARKET_VERSION=$(node -p "require('./.claude-plugin/marketplace.json').plugins[0].version")
+          SERVER_VERSION=$(node -p "require('fs').readFileSync('src/index.ts','utf8').match(/SERVER_VERSION = \"([^\"]+)\"/)[1]")
+          fail=0
+          for pair in "package.json:$PKG_VERSION" ".claude-plugin/plugin.json:$PLUGIN_VERSION" ".claude-plugin/marketplace.json:$MARKET_VERSION" "src/index.ts SERVER_VERSION:$SERVER_VERSION"; do
+            file="${pair%:*}"
+            ver="${pair##*:}"
+            if [ "$ver" != "$TAG_VERSION" ]; then
+              echo "::error::$file version ($ver) does not match tag ($TAG_VERSION)"
+              fail=1
+            fi
+          done
+          if [ "$fail" = "1" ]; then
             exit 1
           fi
+          echo "all version pins match tag $TAG_VERSION"
       - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — Marketplace version pin missed in v0.6.1
+
+`.claude-plugin/marketplace.json` was still pinned to `0.6.0` after v0.6.1 shipped, so `/plugin install squad@gempack` kept resolving to the broken v0.6.0 build. Bumped to `0.6.2` and added a release-workflow check that verifies all four version pins (`package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `src/index.ts SERVER_VERSION`) match the git tag. Future bumps fail loudly if any pin is forgotten.
+
 ### Fixed — Plugin manifest validation: shared docs lifted out of `agents/`
 
 Claude Code's `/plugin install` rejected the v0.6.0 plugin with `Validation errors: agents: Invalid input`. The plugin manifest's `agents: "./agents/"` directive iterated every `.md` file under `agents/`, including the three `_shared/*.md` reference docs (severity matrix + skill specs) — they lack subagent frontmatter and fail validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gempack/squad-mcp",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gempack/squad-mcp",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gempack/squad-mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "MCP server for the squad-dev workflow: classification, risk scoring, agent selection, advisory orchestration",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { logger, setupProcessHandlers } from "./observability/logger.js";
 
 setupProcessHandlers();
 
-const SERVER_VERSION = "0.6.1";
+const SERVER_VERSION = "0.6.2";
 
 const server = new Server(
   {


### PR DESCRIPTION
v0.6.1 missed bumping marketplace.json. /plugin install kept resolving to v0.6.0. Bump to 0.6.2 across all four pins + add CI guard.