### PR TITLE
fix(plugin): agents and commands must be arrays, not strings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "ggemba/squad-mcp"
       },
       "description": "Squad-dev workflow: deterministic classification, risk scoring, agent selection, advisory orchestration over MCP, native subagents, plus /squad and /squad-review slash commands.",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "homepage": "https://github.com/ggemba/squad-mcp"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "squad",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Squad-dev workflow as a Claude Code plugin: classification, risk scoring, agent selection, advisory orchestration. Bundles an MCP server, native subagents, and the /squad and /squad-review slash commands.",
   "license": "Apache-2.0",
   "author": {
@@ -10,8 +10,23 @@
   "homepage": "https://github.com/ggemba/squad-mcp#readme",
   "repository": "https://github.com/ggemba/squad-mcp",
   "keywords": ["mcp", "squad-dev", "code-review", "advisory", "agent"],
-  "agents": "./agents/",
-  "commands": "./commands/",
+  "agents": [
+    "./agents/product-owner.md",
+    "./agents/tech-lead-planner.md",
+    "./agents/tech-lead-consolidator.md",
+    "./agents/senior-architect.md",
+    "./agents/senior-dba.md",
+    "./agents/senior-developer.md",
+    "./agents/senior-dev-reviewer.md",
+    "./agents/senior-dev-security.md",
+    "./agents/senior-qa.md"
+  ],
+  "commands": [
+    "./commands/squad.md",
+    "./commands/squad-review.md",
+    "./commands/brainstorm.md",
+    "./commands/commit-suggest.md"
+  ],
   "skills": "./skills/",
   "mcpServers": {
     "squad": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — Plugin manifest `agents` and `commands` shape (Claude Code rejected v0.6.2)
+
+`/plugin install squad@gempack` failed v0.6.2 with `Validation errors: agents: Invalid input` because `.claude-plugin/plugin.json` declared `"agents": "./agents/"` (string) and `"commands": "./commands/"` (string). Per the Claude Code plugin reference, those fields must be **arrays of explicit file paths** — only `skills` accepts a directory string.
+
+- `.claude-plugin/plugin.json`: `agents` is now a 9-entry array listing each subagent's `.md` path; `commands` is a 4-entry array. `skills` stays as `./skills/`.
+- Bumped to `0.6.3` across all four version pins (the release-yml guard added in v0.6.2 catches future drift).
+
 ### Fixed — Marketplace version pin missed in v0.6.1
 
 `.claude-plugin/marketplace.json` was still pinned to `0.6.0` after v0.6.1 shipped, so `/plugin install squad@gempack` kept resolving to the broken v0.6.0 build. Bumped to `0.6.2` and added a release-workflow check that verifies all four version pins (`package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `src/index.ts SERVER_VERSION`) match the git tag. Future bumps fail loudly if any pin is forgotten.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gempack/squad-mcp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gempack/squad-mcp",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gempack/squad-mcp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "MCP server for the squad-dev workflow: classification, risk scoring, agent selection, advisory orchestration",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { logger, setupProcessHandlers } from "./observability/logger.js";
 
 setupProcessHandlers();
 
-const SERVER_VERSION = "0.6.2";
+const SERVER_VERSION = "0.6.3";
 
 const server = new Server(
   {


### PR DESCRIPTION
v0.6.2 still rejected. Plugin schema requires array of paths for agents/commands. Bump to 0.6.3.