### PR TITLE
fix(plugin): MCP server via npx (dist/ is gitignored, plugin install never builds)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "ggemba/squad-mcp"
       },
       "description": "Squad-dev workflow: deterministic classification, risk scoring, agent selection, advisory orchestration over MCP, native subagents, plus /squad and /squad-review slash commands.",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "Apache-2.0",
       "homepage": "https://github.com/ggemba/squad-mcp"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "squad",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Squad-dev workflow as a Claude Code plugin: classification, risk scoring, agent selection, advisory orchestration. Bundles an MCP server, native subagents, and the /squad and /squad-review slash commands.",
   "license": "Apache-2.0",
   "author": {
@@ -30,8 +30,8 @@
   "skills": "./skills/",
   "mcpServers": {
     "squad": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"]
+      "command": "npx",
+      "args": ["-y", "@gempack/squad-mcp@0.6.5"]
     }
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,9 @@ jobs:
           PLUGIN_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
           MARKET_VERSION=$(node -p "require('./.claude-plugin/marketplace.json').plugins[0].version")
           SERVER_VERSION=$(node -p "require('fs').readFileSync('src/index.ts','utf8').match(/SERVER_VERSION = \"([^\"]+)\"/)[1]")
+          MCP_NPX_PIN=$(node -p "(require('./.claude-plugin/plugin.json').mcpServers.squad.args || []).join(' ').match(/@gempack\/squad-mcp@([0-9]+\.[0-9]+\.[0-9]+)/)?.[1] || ''")
           fail=0
-          for pair in "package.json:$PKG_VERSION" ".claude-plugin/plugin.json:$PLUGIN_VERSION" ".claude-plugin/marketplace.json:$MARKET_VERSION" "src/index.ts SERVER_VERSION:$SERVER_VERSION"; do
+          for pair in "package.json:$PKG_VERSION" ".claude-plugin/plugin.json:$PLUGIN_VERSION" ".claude-plugin/marketplace.json:$MARKET_VERSION" "src/index.ts SERVER_VERSION:$SERVER_VERSION" ".claude-plugin/plugin.json mcpServers.squad npx pin:$MCP_NPX_PIN"; do
             file="${pair%:*}"
             ver="${pair##*:}"
             if [ "$ver" != "$TAG_VERSION" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-05-10
+
+### Fixed
+
+- **Plugin MCP server now runs from npm, not from gitignored `dist/`.** v0.6.4 (and all earlier releases) shipped a plugin manifest pointing at `${CLAUDE_PLUGIN_ROOT}/dist/index.js`. Claude Code's plugin install does a shallow `git clone` and never runs `npm install` / `npm run build`, so `dist/` (gitignored) was missing on disk and the MCP server failed to start with `Failed to reconnect to plugin:squad:squad`. The plugin manifest now uses `command: "npx"` + `args: ["-y", "@gempack/squad-mcp@<version>"]`, pulling the pre-built tarball published with provenance. The plugin still ships agents/commands/skills directly (those are static markdown). Side benefit: plugin and npm install paths now share a single MCP runtime.
+- **`release.yml` version-pin guard** now also verifies the npx pin in `mcpServers.squad.args` matches the git tag — any future bump that forgets this field fails publish.
+
 ## [0.6.4] - 2026-05-10
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gempack/squad-mcp",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gempack/squad-mcp",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gempack/squad-mcp",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "MCP server for the squad-dev workflow: classification, risk scoring, agent selection, advisory orchestration",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { logger, setupProcessHandlers } from "./observability/logger.js";
 
 setupProcessHandlers();
 
-const SERVER_VERSION = "0.6.4";
+const SERVER_VERSION = "0.6.5";
 
 const server = new Server(
   {


### PR DESCRIPTION
Root cause of 'Failed to reconnect to plugin:squad:squad'. Plugin install clones source but doesn't build; dist/ never exists on disk. Switch mcpServers to npx pulling the pre-built npm tarball. Adds CI guard for the npx pin.