### PR TITLE
fix(plugin): build dist on first run (0.14.1 hotfix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "ggemba/squad-mcp"
       },
       "description": "Squad-dev workflow: deterministic classification, risk scoring, agent selection, advisory orchestration over MCP, native subagents, plus /squad:implement and /squad:review slash commands.",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "homepage": "https://github.com/ggemba/squad-mcp"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "squad",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Squad-dev workflow as a Claude Code plugin: classification, risk scoring, agent selection, advisory orchestration. Bundles an MCP server, native subagents, and the /squad:implement and /squad:review slash commands.",
   "license": "Apache-2.0",
   "author": {
@@ -40,7 +40,7 @@
   "mcpServers": {
     "squad": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/bin/launch.mjs"]
     }
   }
 }

--- a/bin/launch.mjs
+++ b/bin/launch.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// First-run builder + MCP server entrypoint.
+//
+// Background: Claude Code installs plugins via `git clone + npm install
+// --ignore-scripts`. The --ignore-scripts flag is a sensible defence against
+// malicious postinstall scripts in transitive deps, but it also means our own
+// `prepare` script never fires. devDeps are installed (esbuild, typescript are
+// on disk) but dist/index.js — the actual MCP server entrypoint — never gets
+// built. The MCP host then tries to spawn `node .../dist/index.js`, that path
+// doesn't exist, and the plugin fails to start.
+//
+// This wrapper bridges the gap: if dist/ is missing it builds once, then
+// dynamically imports the bundled server in-process. The src/index.ts module
+// has top-level await that connects the stdio transport on import, so a plain
+// `await import(...)` is enough to bring the server up — no extra child spawn,
+// no second Node startup cost.
+//
+// Stdio discipline: the MCP wire protocol owns stdout. Every byte of build
+// output below is routed to stderr (fd 2) so it can't corrupt a JSON-RPC
+// frame.
+
+import { existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const dist = resolve(root, "dist/index.js");
+
+if (!existsSync(dist)) {
+  process.stderr.write("[squad-mcp] First run: building dist/ (one-time, ~3-5s)...\n");
+  try {
+    execSync("npm run build", {
+      cwd: root,
+      // Route child stdout AND stderr to our stderr — both fds map to 2.
+      // Keeps stdout pure for the MCP host that will own it after import.
+      stdio: ["ignore", 2, 2],
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[squad-mcp] Build failed (exit ${err.status ?? "?"}).\n` +
+        "[squad-mcp] Required devDeps: esbuild, typescript. If you installed " +
+        "this package with --omit=dev or --production, reinstall without.\n",
+    );
+    process.exit(err.status ?? 1);
+  }
+  if (!existsSync(dist)) {
+    process.stderr.write(
+      "[squad-mcp] Build reported success but dist/index.js is still missing.\n" +
+        `[squad-mcp] Looked at: ${dist}\n`,
+    );
+    process.exit(1);
+  }
+}
+
+// dist/index.js does its own top-level await transport.connect() — importing
+// it is enough to start the server. No second Node process needed.
+await import(pathToFileURL(dist).href);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gempack/squad-mcp",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "MCP server for the squad-dev workflow: classification, risk scoring, agent selection, advisory orchestration",
   "type": "module",
   "license": "Apache-2.0",
@@ -58,6 +58,7 @@
   },
   "files": [
     "dist",
+    "bin",
     "agents",
     "shared",
     "commands",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { logger, setupProcessHandlers } from "./observability/logger.js";
 
 setupProcessHandlers();
 
-const SERVER_VERSION = "0.14.0";
+const SERVER_VERSION = "0.14.1";
 
 const server = new Server(
   {


### PR DESCRIPTION
## Why

The 0.14.0 plugin install fails on fresh setups. Reproducible by running `/plugin install squad@gempack` in a brand-new Claude Code session:

```
Status:    × failed
Command:   node
Args:      /home/gemba/.claude/plugins/cache/gempack/squad/0.14.0/dist/index.js
```

## Root cause

Claude Code installs plugins via `git clone + npm install --ignore-scripts`. `--ignore-scripts` is a sensible defense against malicious postinstall scripts in transitive deps, but it also blocks our own `prepare` script. devDeps land on disk (esbuild, typescript present) but `npm run build` never fires, so `dist/index.js` doesn't exist. The plugin manifest points there and the MCP fails to spawn.

## Fix

New `bin/launch.mjs` wrapper:

```js
if (!existsSync(dist)) {
  // route child stdout AND stderr to fd 2 — MCP host owns stdout
  execSync("npm run build", { cwd: root, stdio: ["ignore", 2, 2] });
}
await import(pathToFileURL(dist).href);  // top-level await loads the server
```

- First invocation: builds dist/ (~3-5s), then loads the server in-process via dynamic import.
- Subsequent invocations: dist/ exists, just import — no measurable overhead vs direct `node dist/index.js`.
- Stdout strictly preserved for MCP JSON-RPC framing.
- Build failures emit a helpful message to stderr and exit non-zero.

Plugin manifest now points at `${CLAUDE_PLUGIN_ROOT}/bin/launch.mjs`. `bin/` added to `package.json` `files` so npx consumers also get the wrapper.

## Manual verification

```bash
rm -rf dist
node bin/launch.mjs < init.json
# [squad-mcp] First run: building dist/ (one-time, ~3-5s)...
# [...build output to stderr...]
# {"result":{...},"jsonrpc":"2.0","id":1}
```

## Test plan

- [ ] CI: all 4 matrix cells pass (linux+windows × node 22+24)
- [ ] Release: tag triggers publish workflow, smoke job validates the published tarball
- [ ] Manual after publish: \`/plugin install squad@gempack\` on a clean Claude Code session → 26 tools available

## Followup

Long-term, the right answer is for `claude-plugin` to allow declaring a build step in plugin.json — so the host can run it explicitly without trusting transitive postinstall scripts. Will open an upstream issue once 0.14.1 is shipped.